### PR TITLE
Remove initial check for `baseFeeChangeDenom`

### DIFF
--- a/contracts/blade/NetworkParams.sol
+++ b/contracts/blade/NetworkParams.sol
@@ -72,8 +72,7 @@ contract NetworkParams is Ownable2Step, Initializable {
                 initParams.newWithdrawalWaitPeriod != 0 &&
                 initParams.newBlockTime != 0 &&
                 initParams.newBlockTimeDrift != 0 &&
-                initParams.newVotingPeriod != 0 &&
-                initParams.newBaseFeeChangeDenom != 0,
+                initParams.newVotingPeriod != 0,
             "NetworkParams: INVALID_INPUT"
         );
         checkpointBlockInterval = initParams.newCheckpointBlockInterval;


### PR DESCRIPTION
This PR removes the check in the `NetworkParams.initialize` function for `baseFeeChangeDenom != 0`. There will be chains that will not run `london` fork, so this value can be 0 initially. 