### PR TITLE
Bridge rollback mechanism

### DIFF
--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -173,7 +173,7 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, System {
                 newChildTokenTemplate != address(0),
             "ChildERC1155Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC1155Predicate = newRootERC1155Predicate;

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -8,6 +8,7 @@ import "../interfaces/blade/IChildERC1155Predicate.sol";
 import "../interfaces/blade/IChildERC1155.sol";
 import "../interfaces/IStateSender.sol";
 import "./System.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildERC1155Predicate
@@ -15,7 +16,7 @@ import "./System.sol";
     @notice Enables ERC1155 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildERC1155Predicate is IChildERC1155Predicate, Initializable, System {
+contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, System {
     /// @custom:security write-protection="onlySystemCall()"
     IStateSender public l2StateSender;
     /// @custom:security write-protection="onlySystemCall()"
@@ -24,11 +25,6 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Initializable, System 
     address public rootERC1155Predicate;
     /// @custom:security write-protection="onlySystemCall()"
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant DEPOSIT_BATCH_SIG = keccak256("DEPOSIT_BATCH");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant WITHDRAW_BATCH_SIG = keccak256("WITHDRAW_BATCH");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -177,6 +173,7 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Initializable, System 
                 newChildTokenTemplate != address(0),
             "ChildERC1155Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC1155Predicate = newRootERC1155Predicate;

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -9,6 +9,7 @@ import "../interfaces/blade/IChildERC20Predicate.sol";
 import "../interfaces/blade/IChildERC20.sol";
 import "../interfaces/IStateSender.sol";
 import "./System.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildERC20Predicate
@@ -16,7 +17,7 @@ import "./System.sol";
     @notice Enables ERC20 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildERC20Predicate is IChildERC20Predicate, Initializable, System {
+contract ChildERC20Predicate is IChildERC20Predicate, Predicate, System {
     using SafeERC20 for IERC20;
 
     /// @custom:security write-protection="onlySystemCall()"
@@ -27,9 +28,6 @@ contract ChildERC20Predicate is IChildERC20Predicate, Initializable, System {
     address public rootERC20Predicate;
     /// @custom:security write-protection="onlySystemCall()"
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -141,6 +139,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Initializable, System {
                 newChildTokenTemplate != address(0),
             "ChildERC20Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC20Predicate = newRootERC20Predicate;

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -139,7 +139,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, System {
                 newChildTokenTemplate != address(0),
             "ChildERC20Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC20Predicate = newRootERC20Predicate;

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -165,7 +165,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, System {
                 newChildTokenTemplate != address(0),
             "ChildERC721Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC721Predicate = newRootERC721Predicate;

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -8,6 +8,7 @@ import "../interfaces/blade/IChildERC721Predicate.sol";
 import "../interfaces/blade/IChildERC721.sol";
 import "../interfaces/IStateSender.sol";
 import "./System.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildERC721Predicate
@@ -15,7 +16,7 @@ import "./System.sol";
     @notice Enables ERC721 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildERC721Predicate is IChildERC721Predicate, Initializable, System {
+contract ChildERC721Predicate is IChildERC721Predicate, Predicate, System {
     /// @custom:security write-protection="onlySystemCall()"
     IStateSender public l2StateSender;
     /// @custom:security write-protection="onlySystemCall()"
@@ -24,11 +25,6 @@ contract ChildERC721Predicate is IChildERC721Predicate, Initializable, System {
     address public rootERC721Predicate;
     /// @custom:security write-protection="onlySystemCall()"
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant DEPOSIT_BATCH_SIG = keccak256("DEPOSIT_BATCH");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant WITHDRAW_BATCH_SIG = keccak256("WITHDRAW_BATCH");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -169,6 +165,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Initializable, System {
                 newChildTokenTemplate != address(0),
             "ChildERC721Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         rootERC721Predicate = newRootERC721Predicate;

--- a/contracts/blade/RootMintableERC1155Predicate.sol
+++ b/contracts/blade/RootMintableERC1155Predicate.sol
@@ -138,7 +138,7 @@ contract RootMintableERC1155Predicate is Predicate, ERC1155Holder, IRootMintable
                 owner != address(0),
             "RootMintableERC1155Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init(owner);
+        predicateInit(owner);
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         childERC1155Predicate = newChildERC1155Predicate;

--- a/contracts/blade/RootMintableERC1155PredicateAccessList.sol
+++ b/contracts/blade/RootMintableERC1155PredicateAccessList.sol
@@ -20,7 +20,7 @@ contract RootMintableERC1155PredicateAccessList is AccessList, RootMintableERC11
         bool newUseBlockList,
         address newOwner
     ) public virtual onlySystemCall initializer {
-        _initialize(newL2StateSender, newStateReceiver, newChildERC1155Predicate, newChildTokenTemplate);
+        _initialize(newL2StateSender, newStateReceiver, newChildERC1155Predicate, newChildTokenTemplate, newOwner);
         _initializeAccessList(newUseAllowList, newUseBlockList);
         _transferOwnership(newOwner);
     }

--- a/contracts/blade/RootMintableERC20Predicate.sol
+++ b/contracts/blade/RootMintableERC20Predicate.sol
@@ -131,7 +131,7 @@ contract RootMintableERC20Predicate is IRootMintableERC20Predicate, Predicate, S
                 owner != address(0),
             "RootMintableERC20Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init(owner);
+        predicateInit(owner);
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         childERC20Predicate = newChildERC20Predicate;

--- a/contracts/blade/RootMintableERC20PredicateAccessList.sol
+++ b/contracts/blade/RootMintableERC20PredicateAccessList.sol
@@ -20,7 +20,7 @@ contract RootMintableERC20PredicateAccessList is AccessList, RootMintableERC20Pr
         bool newUseBlockList,
         address newOwner
     ) public virtual onlySystemCall initializer {
-        _initialize(newL2StateSender, newStateReceiver, newChildERC20Predicate, newChildTokenTemplate);
+        _initialize(newL2StateSender, newStateReceiver, newChildERC20Predicate, newChildTokenTemplate, newOwner);
         _initializeAccessList(newUseAllowList, newUseBlockList);
         _transferOwnership(newOwner);
     }

--- a/contracts/blade/RootMintableERC721Predicate.sol
+++ b/contracts/blade/RootMintableERC721Predicate.sol
@@ -141,7 +141,7 @@ contract RootMintableERC721Predicate is Predicate, ERC721Holder, System, IRootMi
                 owner != address(0),
             "RootMintableERC721Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init(owner);
+        predicateInit(owner);
         l2StateSender = IStateSender(newL2StateSender);
         stateReceiver = newStateReceiver;
         childERC721Predicate = newChildERC721Predicate;

--- a/contracts/blade/RootMintableERC721PredicateAccessList.sol
+++ b/contracts/blade/RootMintableERC721PredicateAccessList.sol
@@ -20,7 +20,7 @@ contract RootMintableERC721PredicateAccessList is AccessList, RootMintableERC721
         bool newUseBlockList,
         address newOwner
     ) public virtual onlySystemCall initializer {
-        _initialize(newL2StateSender, newStateReceiver, newChildERC721Predicate, newChildTokenTemplate);
+        _initialize(newL2StateSender, newStateReceiver, newChildERC721Predicate, newChildTokenTemplate, newOwner);
         _initializeAccessList(newUseAllowList, newUseBlockList);
         _transferOwnership(newOwner);
     }

--- a/contracts/bridge/ChildMintableERC1155Predicate.sol
+++ b/contracts/bridge/ChildMintableERC1155Predicate.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 import "../interfaces/bridge/IChildMintableERC1155Predicate.sol";
 import "../interfaces/blade/IChildERC1155.sol";
 import "../interfaces/IStateSender.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildMintableERC1155Predicate
@@ -14,16 +15,11 @@ import "../interfaces/IStateSender.sol";
     @notice Enables mintable ERC1155 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildMintableERC1155Predicate is Initializable, IChildMintableERC1155Predicate {
+contract ChildMintableERC1155Predicate is Predicate, IChildMintableERC1155Predicate {
     IStateSender public stateSender;
     address public exitHelper;
     address public rootERC1155Predicate;
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant DEPOSIT_BATCH_SIG = keccak256("DEPOSIT_BATCH");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant WITHDRAW_BATCH_SIG = keccak256("WITHDRAW_BATCH");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -138,6 +134,7 @@ contract ChildMintableERC1155Predicate is Initializable, IChildMintableERC1155Pr
                 newChildTokenTemplate != address(0),
             "ChildMintableERC1155Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC1155Predicate = newRootERC1155Predicate;

--- a/contracts/bridge/ChildMintableERC1155Predicate.sol
+++ b/contracts/bridge/ChildMintableERC1155Predicate.sol
@@ -134,7 +134,7 @@ contract ChildMintableERC1155Predicate is Predicate, IChildMintableERC1155Predic
                 newChildTokenTemplate != address(0),
             "ChildMintableERC1155Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC1155Predicate = newRootERC1155Predicate;

--- a/contracts/bridge/ChildMintableERC20Predicate.sol
+++ b/contracts/bridge/ChildMintableERC20Predicate.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 import "../interfaces/bridge/IChildMintableERC20Predicate.sol";
 import "../interfaces/blade/IChildERC20.sol";
 import "../interfaces/IStateSender.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildMintableERC20Predicate
@@ -15,16 +16,13 @@ import "../interfaces/IStateSender.sol";
     @notice Enables ERC20 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildMintableERC20Predicate is Initializable, IChildMintableERC20Predicate {
+contract ChildMintableERC20Predicate is Predicate, IChildMintableERC20Predicate {
     using SafeERC20 for IERC20;
 
     IStateSender public stateSender;
     address public exitHelper;
     address public rootERC20Predicate;
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -109,6 +107,7 @@ contract ChildMintableERC20Predicate is Initializable, IChildMintableERC20Predic
                 newChildTokenTemplate != address(0),
             "ChildMintableERC20Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC20Predicate = newRootERC20Predicate;

--- a/contracts/bridge/ChildMintableERC20Predicate.sol
+++ b/contracts/bridge/ChildMintableERC20Predicate.sol
@@ -107,7 +107,7 @@ contract ChildMintableERC20Predicate is Predicate, IChildMintableERC20Predicate 
                 newChildTokenTemplate != address(0),
             "ChildMintableERC20Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC20Predicate = newRootERC20Predicate;

--- a/contracts/bridge/ChildMintableERC721Predicate.sol
+++ b/contracts/bridge/ChildMintableERC721Predicate.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 import "../interfaces/bridge/IChildMintableERC721Predicate.sol";
 import "../interfaces/blade/IChildERC721.sol";
 import "../interfaces/IStateSender.sol";
+import "../lib/Predicate.sol";
 
 /**
     @title ChildMintableERC721Predicate
@@ -14,16 +15,11 @@ import "../interfaces/IStateSender.sol";
     @notice Enables mintable ERC721 token deposits and withdrawals across an arbitrary root chain and child chain
  */
 // solhint-disable reason-string
-contract ChildMintableERC721Predicate is Initializable, IChildMintableERC721Predicate {
+contract ChildMintableERC721Predicate is Predicate, IChildMintableERC721Predicate {
     IStateSender public stateSender;
     address public exitHelper;
     address public rootERC721Predicate;
     address public childTokenTemplate;
-    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
-    bytes32 public constant DEPOSIT_BATCH_SIG = keccak256("DEPOSIT_BATCH");
-    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
-    bytes32 public constant WITHDRAW_BATCH_SIG = keccak256("WITHDRAW_BATCH");
-    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
 
     mapping(address => address) public rootTokenToChildToken;
 
@@ -134,6 +130,7 @@ contract ChildMintableERC721Predicate is Initializable, IChildMintableERC721Pred
                 newChildTokenTemplate != address(0),
             "ChildMintableERC721Predicate: BAD_INITIALIZATION"
         );
+        __Predicate_init();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC721Predicate = newRootERC721Predicate;

--- a/contracts/bridge/ChildMintableERC721Predicate.sol
+++ b/contracts/bridge/ChildMintableERC721Predicate.sol
@@ -130,7 +130,7 @@ contract ChildMintableERC721Predicate is Predicate, IChildMintableERC721Predicat
                 newChildTokenTemplate != address(0),
             "ChildMintableERC721Predicate: BAD_INITIALIZATION"
         );
-        __Predicate_init();
+        predicateInit();
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         rootERC721Predicate = newRootERC721Predicate;

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -38,7 +38,7 @@ contract RootERC1155Predicate is Predicate, ERC1155Holder, IRootERC1155Predicate
             "RootERC1155Predicate: BAD_INITIALIZATION"
         );
 
-        __Predicate_init(owner);
+        predicateInit(owner);
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         childERC1155Predicate = newChildERC1155Predicate;

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -45,7 +45,7 @@ contract RootERC20Predicate is Predicate, IRootERC20Predicate {
             "RootERC20Predicate: BAD_INITIALIZATION"
         );
 
-        __Predicate_init(owner);
+        predicateInit(owner);
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         childERC20Predicate = newChildERC20Predicate;

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -38,7 +38,7 @@ contract RootERC721Predicate is Predicate, ERC721Holder, IRootERC721Predicate {
             "RootERC721Predicate: BAD_INITIALIZATION"
         );
 
-        __Predicate_init(owner);
+        predicateInit(owner);
         stateSender = IStateSender(newStateSender);
         exitHelper = newExitHelper;
         childERC721Predicate = newChildERC721Predicate;

--- a/contracts/lib/AccessList.sol
+++ b/contracts/lib/AccessList.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IAddressList} from "../interfaces/IAddressList.sol";
 import {System} from "../blade/System.sol";
 
@@ -10,7 +10,7 @@ import {System} from "../blade/System.sol";
     @author Polygon Technology (@QEDK, @wschwab)
     @notice Checks the access lists to see if an address is allowed and not blocked
  */
-contract AccessList is Ownable2StepUpgradeable, System {
+contract AccessList is OwnableUpgradeable, System {
     bool private _useAllowList;
     bool private _useBlockList;
 

--- a/contracts/lib/Predicate.sol
+++ b/contracts/lib/Predicate.sol
@@ -13,11 +13,11 @@ abstract contract Predicate is OwnableUpgradeable {
 
     mapping(address => bool) trustedRelayers;
 
-    function __Predicate_init() internal onlyInitializing {
+    function predicateInit() internal onlyInitializing {
         __Ownable_init();
     }
 
-    function __Predicate_init(address owner) internal onlyInitializing {
+    function predicateInit(address owner) internal onlyInitializing {
         __Ownable_init();
         transferOwnership(owner);
     } 

--- a/contracts/lib/Predicate.sol
+++ b/contracts/lib/Predicate.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+abstract contract Predicate is Ownable2StepUpgradeable {
+    bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
+    bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
+    bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
+    bytes32 public constant ROLLBACK_SIG = keccak256("ROLLBACK");
+    bytes32 public constant DEPOSIT_BATCH_SIG = keccak256("DEPOSIT_BATCH");
+    bytes32 public constant WITHDRAW_BATCH_SIG = keccak256("WITHDRAW_BATCH");
+
+    mapping(address => bool) trustedRelayers;
+
+    function __Predicate_init() internal onlyInitializing {
+        __Ownable2Step_init();
+    }
+
+    function __Predicate_init(address owner) internal onlyInitializing {
+        __Ownable2Step_init();
+        transferOwnership(owner);
+    } 
+
+    function addTrustedRelayer(address relayer) external onlyOwner {
+        require(msg.sender == address(this), "Predicate: INVALID_SENDER");
+        trustedRelayers[relayer] = true;
+    }
+
+    function removeTrustedRelayer(address relayer) external onlyOwner {
+        require(msg.sender == address(this), "Predicate: INVALID_SENDER");
+        trustedRelayers[relayer] = false;
+    }
+}

--- a/contracts/lib/Predicate.sol
+++ b/contracts/lib/Predicate.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-abstract contract Predicate is Ownable2StepUpgradeable {
+abstract contract Predicate is OwnableUpgradeable {
     bytes32 public constant DEPOSIT_SIG = keccak256("DEPOSIT");
     bytes32 public constant WITHDRAW_SIG = keccak256("WITHDRAW");
     bytes32 public constant MAP_TOKEN_SIG = keccak256("MAP_TOKEN");
@@ -14,11 +14,11 @@ abstract contract Predicate is Ownable2StepUpgradeable {
     mapping(address => bool) trustedRelayers;
 
     function __Predicate_init() internal onlyInitializing {
-        __Ownable2Step_init();
+        __Ownable_init();
     }
 
     function __Predicate_init(address owner) internal onlyInitializing {
-        __Ownable2Step_init();
+        __Ownable_init();
         transferOwnership(owner);
     } 
 

--- a/docs/blade/ChildERC1155Predicate.md
+++ b/docs/blade/ChildERC1155Predicate.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -380,23 +369,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -488,7 +460,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -672,23 +644,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC1155Predicate.md
+++ b/docs/blade/ChildERC1155Predicate.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -248,6 +265,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
 ### childTokenTemplate
 
 ```solidity
@@ -319,6 +363,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC1155Predicate
 
 ```solidity
@@ -374,6 +479,22 @@ function stateReceiver() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -551,6 +672,40 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/ChildERC1155PredicateAccessList.md
+++ b/docs/blade/ChildERC1155PredicateAccessList.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -258,6 +275,22 @@ function acceptOwnership() external nonpayable
 
 *The new owner accepts the ownership transfer.*
 
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -385,6 +418,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/ChildERC1155PredicateAccessList.md
+++ b/docs/blade/ChildERC1155PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -394,23 +383,6 @@ function owner() external view returns (address)
 
 
 *Returns the address of the current owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
 
 
 #### Returns
@@ -542,7 +514,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -760,23 +732,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC20Predicate.md
+++ b/docs/blade/ChildERC20Predicate.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -381,23 +370,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -489,7 +461,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -608,23 +580,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC20Predicate.md
+++ b/docs/blade/ChildERC20Predicate.md
@@ -44,6 +44,23 @@ function BLOCKLIST_PRECOMPILE() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -146,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -197,6 +231,23 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -213,6 +264,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -286,6 +364,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC20Predicate
 
 ```solidity
@@ -341,6 +480,22 @@ function stateReceiver() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -453,6 +608,40 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/ChildERC20PredicateAccessList.md
+++ b/docs/blade/ChildERC20PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -396,23 +385,6 @@ function owner() external view returns (address)
 
 
 *Returns the address of the current owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
 
 
 #### Returns
@@ -544,7 +516,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -697,23 +669,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC20PredicateAccessList.md
+++ b/docs/blade/ChildERC20PredicateAccessList.md
@@ -44,6 +44,23 @@ function BLOCKLIST_PRECOMPILE() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -146,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -197,6 +231,23 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -224,6 +275,22 @@ function acceptOwnership() external nonpayable
 
 *The new owner accepts the ownership transfer.*
 
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -353,6 +420,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/ChildERC721Predicate.md
+++ b/docs/blade/ChildERC721Predicate.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -380,23 +369,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -488,7 +460,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -665,23 +637,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC721Predicate.md
+++ b/docs/blade/ChildERC721Predicate.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -248,6 +265,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
 ### childTokenTemplate
 
 ```solidity
@@ -319,6 +363,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC721Predicate
 
 ```solidity
@@ -374,6 +479,22 @@ function stateReceiver() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -544,6 +665,40 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/ChildERC721PredicateAccessList.md
+++ b/docs/blade/ChildERC721PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -394,23 +383,6 @@ function owner() external view returns (address)
 
 
 *Returns the address of the current owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
 
 
 #### Returns
@@ -542,7 +514,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -753,23 +725,6 @@ event L2TokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/ChildERC721PredicateAccessList.md
+++ b/docs/blade/ChildERC721PredicateAccessList.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -258,6 +275,22 @@ function acceptOwnership() external nonpayable
 
 *The new owner accepts the ownership transfer.*
 
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -385,6 +418,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/RootMintableERC1155Predicate.md
+++ b/docs/blade/RootMintableERC1155Predicate.md
@@ -61,6 +61,23 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_BATCH_SIG
 
 ```solidity
@@ -94,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC1155Predicate
 
@@ -188,7 +232,7 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC1155Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC1155Predicate, address newChildTokenTemplate, address owner) external nonpayable
 ```
 
 Initialization function for RootMintableERC1155Predicate
@@ -202,7 +246,8 @@ Initialization function for RootMintableERC1155Predicate
 | newL2StateSender | address | Address of L2StateSender to send deposit information to |
 | newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
 | newChildERC1155Predicate | address | Address of child ERC1155 predicate to communicate with |
-| newChildTokenTemplate | address | undefined |
+| newChildTokenTemplate | address | Address of child token template to calculate child token addresses |
+| owner | address | Address of the owner of the contract |
 
 ### l2StateSender
 
@@ -313,6 +358,67 @@ Function to be used for token withdrawals
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -373,6 +479,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -494,6 +616,40 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/RootMintableERC1155Predicate.md
+++ b/docs/blade/RootMintableERC1155Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -375,23 +364,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -488,7 +460,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -616,23 +588,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/RootMintableERC1155PredicateAccessList.md
+++ b/docs/blade/RootMintableERC1155PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -550,23 +539,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -695,7 +667,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -857,23 +829,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/RootMintableERC1155PredicateAccessList.md
+++ b/docs/blade/RootMintableERC1155PredicateAccessList.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -259,6 +276,22 @@ function acceptOwnership() external nonpayable
 *The new owner accepts the ownership transfer.*
 
 
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
 ### childERC1155Predicate
 
 ```solidity
@@ -352,6 +385,26 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC1155Predicate, address newChildTokenTemplate, address owner) external nonpayable
+```
+
+Initialization function for RootMintableERC1155Predicate
+
+*Can only be called once.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newL2StateSender | address | Address of L2StateSender to send deposit information to |
+| newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
+| newChildERC1155Predicate | address | Address of child ERC1155 predicate to communicate with |
+| newChildTokenTemplate | address | Address of child token template to calculate child token addresses |
+| owner | address | Address of the owner of the contract |
+
+### initialize
+
+```solidity
 function initialize(address newL2StateSender, address newStateReceiver, address newChildERC1155Predicate, address newChildTokenTemplate, bool newUseAllowList, bool newUseBlockList, address newOwner) external nonpayable
 ```
 
@@ -370,25 +423,6 @@ function initialize(address newL2StateSender, address newStateReceiver, address 
 | newUseAllowList | bool | undefined |
 | newUseBlockList | bool | undefined |
 | newOwner | address | undefined |
-
-### initialize
-
-```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC1155Predicate, address newChildTokenTemplate) external nonpayable
-```
-
-Initialization function for RootMintableERC1155Predicate
-
-*Can only be called once.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newL2StateSender | address | Address of L2StateSender to send deposit information to |
-| newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
-| newChildERC1155Predicate | address | Address of child ERC1155 predicate to communicate with |
-| newChildTokenTemplate | address | undefined |
 
 ### l2StateSender
 
@@ -532,6 +566,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/RootMintableERC20Predicate.md
+++ b/docs/blade/RootMintableERC20Predicate.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -455,23 +444,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -546,7 +518,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -630,23 +602,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/RootMintableERC20Predicate.md
+++ b/docs/blade/RootMintableERC20Predicate.md
@@ -44,6 +44,23 @@ function BLOCKLIST_PRECOMPILE() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -146,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -197,6 +231,23 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -213,6 +264,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC20Predicate
 
@@ -286,7 +364,7 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC20Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC20Predicate, address newChildTokenTemplate, address owner) external nonpayable
 ```
 
 Initialization function for RootMintableERC20Predicate
@@ -301,6 +379,7 @@ Initialization function for RootMintableERC20Predicate
 | newStateReceiver | address | Address of StateReceiver to receive deposit information from |
 | newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
 | newChildTokenTemplate | address | Address of child token implementation to deploy clones of |
+| owner | address | Address of the owner of the contract |
 
 ### l2StateSender
 
@@ -359,6 +438,67 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -397,6 +537,22 @@ function stateReceiver() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -474,6 +630,40 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/RootMintableERC20PredicateAccessList.md
+++ b/docs/blade/RootMintableERC20PredicateAccessList.md
@@ -44,6 +44,23 @@ function BLOCKLIST_PRECOMPILE() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -146,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -197,6 +231,23 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -224,6 +275,22 @@ function acceptOwnership() external nonpayable
 
 *The new owner accepts the ownership transfer.*
 
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC20Predicate
 
@@ -297,6 +364,26 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC20Predicate, address newChildTokenTemplate, address owner) external nonpayable
+```
+
+Initialization function for RootMintableERC20Predicate
+
+*Can only be called once.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newL2StateSender | address | Address of L2StateSender to send exit information to |
+| newStateReceiver | address | Address of StateReceiver to receive deposit information from |
+| newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
+| newChildTokenTemplate | address | Address of child token implementation to deploy clones of |
+| owner | address | Address of the owner of the contract |
+
+### initialize
+
+```solidity
 function initialize(address newL2StateSender, address newStateReceiver, address newChildERC20Predicate, address newChildTokenTemplate, bool newUseAllowList, bool newUseBlockList, address newOwner) external nonpayable
 ```
 
@@ -315,25 +402,6 @@ function initialize(address newL2StateSender, address newStateReceiver, address 
 | newUseAllowList | bool | undefined |
 | newUseBlockList | bool | undefined |
 | newOwner | address | undefined |
-
-### initialize
-
-```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC20Predicate, address newChildTokenTemplate) external nonpayable
-```
-
-Initialization function for RootMintableERC20Predicate
-
-*Can only be called once.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newL2StateSender | address | Address of L2StateSender to send exit information to |
-| newStateReceiver | address | Address of StateReceiver to receive deposit information from |
-| newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
-| newChildTokenTemplate | address | Address of child token implementation to deploy clones of |
 
 ### l2StateSender
 
@@ -425,6 +493,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/RootMintableERC20PredicateAccessList.md
+++ b/docs/blade/RootMintableERC20PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -477,23 +466,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -600,7 +572,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -718,23 +690,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/RootMintableERC721Predicate.md
+++ b/docs/blade/RootMintableERC721Predicate.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -247,6 +264,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC721Predicate
 
@@ -338,7 +382,7 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC721Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC721Predicate, address newChildTokenTemplate, address owner) external nonpayable
 ```
 
 Initialization function for RootMintableERC721Predicate
@@ -353,6 +397,7 @@ Initialization function for RootMintableERC721Predicate
 | newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
 | newChildERC721Predicate | address | Address of child ERC721 predicate to communicate with |
 | newChildTokenTemplate | address | Address of child token template to calculate child token addresses |
+| owner | address | Address of the owner of the contract |
 
 ### l2StateSender
 
@@ -436,6 +481,67 @@ Function to be used for token withdrawals
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -474,6 +580,22 @@ function stateReceiver() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -591,6 +713,40 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/blade/RootMintableERC721Predicate.md
+++ b/docs/blade/RootMintableERC721Predicate.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -498,23 +487,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -589,7 +561,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -713,23 +685,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/blade/RootMintableERC721PredicateAccessList.md
+++ b/docs/blade/RootMintableERC721PredicateAccessList.md
@@ -163,6 +163,23 @@ function READ_ADDRESSLIST_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### SYSTEM
 
 ```solidity
@@ -259,6 +276,22 @@ function acceptOwnership() external nonpayable
 *The new owner accepts the ownership transfer.*
 
 
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
 ### childERC721Predicate
 
 ```solidity
@@ -349,6 +382,26 @@ Function to deposit tokens from the depositor to another address on the child ch
 ### initialize
 
 ```solidity
+function initialize(address newL2StateSender, address newStateReceiver, address newChildERC721Predicate, address newChildTokenTemplate, address owner) external nonpayable
+```
+
+Initialization function for RootMintableERC721Predicate
+
+*Can only be called once.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newL2StateSender | address | Address of L2StateSender to send deposit information to |
+| newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
+| newChildERC721Predicate | address | Address of child ERC721 predicate to communicate with |
+| newChildTokenTemplate | address | Address of child token template to calculate child token addresses |
+| owner | address | Address of the owner of the contract |
+
+### initialize
+
+```solidity
 function initialize(address newL2StateSender, address newStateReceiver, address newChildERC721Predicate, address newChildTokenTemplate, bool newUseAllowList, bool newUseBlockList, address newOwner) external nonpayable
 ```
 
@@ -367,25 +420,6 @@ function initialize(address newL2StateSender, address newStateReceiver, address 
 | newUseAllowList | bool | undefined |
 | newUseBlockList | bool | undefined |
 | newOwner | address | undefined |
-
-### initialize
-
-```solidity
-function initialize(address newL2StateSender, address newStateReceiver, address newChildERC721Predicate, address newChildTokenTemplate) external nonpayable
-```
-
-Initialization function for RootMintableERC721Predicate
-
-*Can only be called once.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newL2StateSender | address | Address of L2StateSender to send deposit information to |
-| newStateReceiver | address | Address of StateReceiver to receive withdrawal information from |
-| newChildERC721Predicate | address | Address of child ERC721 predicate to communicate with |
-| newChildTokenTemplate | address | Address of child token template to calculate child token addresses |
 
 ### l2StateSender
 
@@ -502,6 +536,22 @@ function pendingOwner() external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### renounceOwnership
 

--- a/docs/blade/RootMintableERC721PredicateAccessList.md
+++ b/docs/blade/RootMintableERC721PredicateAccessList.md
@@ -265,17 +265,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -520,23 +509,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -643,7 +615,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -801,23 +773,6 @@ event L2MintableTokenMapped(address indexed rootToken, address indexed childToke
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/ChildMintableERC1155Predicate.md
+++ b/docs/bridge/ChildMintableERC1155Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -227,23 +216,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -335,7 +307,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -519,23 +491,6 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/ChildMintableERC1155Predicate.md
+++ b/docs/bridge/ChildMintableERC1155Predicate.md
@@ -61,6 +61,23 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_BATCH_SIG
 
 ```solidity
@@ -94,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -166,6 +210,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC1155Predicate
 
 ```solidity
@@ -221,6 +326,22 @@ function stateSender() external view returns (contract IStateSender)
 | Name | Type | Description |
 |---|---|---|
 | _0 | contract IStateSender | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -398,6 +519,40 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/bridge/ChildMintableERC20Predicate.md
+++ b/docs/bridge/ChildMintableERC20Predicate.md
@@ -10,6 +10,23 @@ Enables ERC20 token deposits and withdrawals across an arbitrary root chain and 
 
 ## Methods
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -44,6 +61,40 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -60,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -132,6 +210,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC20Predicate
 
 ```solidity
@@ -187,6 +326,22 @@ function stateSender() external view returns (contract IStateSender)
 | Name | Type | Description |
 |---|---|---|
 | _0 | contract IStateSender | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -299,6 +454,40 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/bridge/ChildMintableERC20Predicate.md
+++ b/docs/bridge/ChildMintableERC20Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -227,23 +216,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -335,7 +307,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -454,23 +426,6 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/ChildMintableERC721Predicate.md
+++ b/docs/bridge/ChildMintableERC721Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -227,23 +216,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -335,7 +307,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -512,23 +484,6 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/ChildMintableERC721Predicate.md
+++ b/docs/bridge/ChildMintableERC721Predicate.md
@@ -61,6 +61,23 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_BATCH_SIG
 
 ```solidity
@@ -94,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childTokenTemplate
 
@@ -166,6 +210,67 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootERC721Predicate
 
 ```solidity
@@ -221,6 +326,22 @@ function stateSender() external view returns (contract IStateSender)
 | Name | Type | Description |
 |---|---|---|
 | _0 | contract IStateSender | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 ### withdraw
 
@@ -391,6 +512,40 @@ event MintableTokenMapped(address indexed rootToken, address indexed childToken)
 |---|---|---|
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 
 

--- a/docs/bridge/RootERC1155Predicate.md
+++ b/docs/bridge/RootERC1155Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -375,23 +364,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -488,7 +460,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -599,23 +571,6 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/RootERC1155Predicate.md
+++ b/docs/bridge/RootERC1155Predicate.md
@@ -61,6 +61,23 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_BATCH_SIG
 
 ```solidity
@@ -94,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC1155Predicate
 
@@ -205,7 +249,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC1155Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC1155Predicate, address newChildTokenTemplate, address owner) external nonpayable
 ```
 
 Initialization function for RootERC1155Predicate
@@ -220,6 +264,7 @@ Initialization function for RootERC1155Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC1155Predicate | address | Address of child ERC1155 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
+| owner | address | undefined |
 
 ### mapToken
 
@@ -313,6 +358,67 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -373,6 +479,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -477,6 +599,40 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 ### TokenMapped
 

--- a/docs/bridge/RootERC20Predicate.md
+++ b/docs/bridge/RootERC20Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -320,23 +309,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -411,7 +383,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -478,23 +450,6 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/RootERC20Predicate.md
+++ b/docs/bridge/RootERC20Predicate.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### DEPOSIT_SIG
 
 ```solidity
@@ -44,6 +61,40 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_SIG
 
 ```solidity
@@ -60,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC20Predicate
 
@@ -150,7 +228,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address newNativeTokenRoot) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC20Predicate, address newChildTokenTemplate, address newNativeTokenRoot, address owner) external nonpayable
 ```
 
 Initialization function for RootERC20Predicate
@@ -164,8 +242,9 @@ Initialization function for RootERC20Predicate
 | newStateSender | address | Address of StateSender to send deposit information to |
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC20Predicate | address | Address of child ERC20 predicate to communicate with |
-| newChildTokenTemplate | address | undefined |
-| newNativeTokenRoot | address | undefined |
+| newChildTokenTemplate | address | Address of child token template to clone |
+| newNativeTokenRoot | address | Address of root native token |
+| owner | address | Address of the owner of the contract |
 
 ### mapToken
 
@@ -224,6 +303,67 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -262,6 +402,22 @@ function stateSender() external view returns (contract IStateSender)
 | Name | Type | Description |
 |---|---|---|
 | _0 | contract IStateSender | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -322,6 +478,40 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 ### TokenMapped
 

--- a/docs/bridge/RootERC721Predicate.md
+++ b/docs/bridge/RootERC721Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -345,23 +334,6 @@ function owner() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### removeTrustedRelayer
 
 ```solidity
@@ -436,7 +408,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -543,23 +515,6 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/bridge/RootERC721Predicate.md
+++ b/docs/bridge/RootERC721Predicate.md
@@ -61,6 +61,23 @@ function MAP_TOKEN_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
 ### WITHDRAW_BATCH_SIG
 
 ```solidity
@@ -94,6 +111,33 @@ function WITHDRAW_SIG() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
 
 ### childERC721Predicate
 
@@ -202,7 +246,7 @@ function exitHelper() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(address newStateSender, address newExitHelper, address newChildERC721Predicate, address newChildTokenTemplate) external nonpayable
+function initialize(address newStateSender, address newExitHelper, address newChildERC721Predicate, address newChildTokenTemplate, address owner) external nonpayable
 ```
 
 Initialization function for RootERC721Predicate
@@ -217,6 +261,7 @@ Initialization function for RootERC721Predicate
 | newExitHelper | address | Address of ExitHelper to receive withdrawal information from |
 | newChildERC721Predicate | address | Address of child ERC721 predicate to communicate with |
 | newChildTokenTemplate | address | undefined |
+| owner | address | undefined |
 
 ### mapToken
 
@@ -283,6 +328,67 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
 ### rootTokenToChildToken
 
 ```solidity
@@ -321,6 +427,22 @@ function stateSender() external view returns (contract IStateSender)
 | Name | Type | Description |
 |---|---|---|
 | _0 | contract IStateSender | undefined |
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
 
 
 
@@ -421,6 +543,40 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
 
 ### TokenMapped
 

--- a/docs/lib/AccessList.md
+++ b/docs/lib/AccessList.md
@@ -163,17 +163,6 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### owner
 
 ```solidity
@@ -183,23 +172,6 @@ function owner() external view returns (address)
 
 
 *Returns the address of the current owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
 
 
 #### Returns
@@ -259,7 +231,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -320,23 +292,6 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/lib/Predicate.md
+++ b/docs/lib/Predicate.md
@@ -112,17 +112,6 @@ function WITHDRAW_SIG() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### acceptOwnership
-
-```solidity
-function acceptOwnership() external nonpayable
-```
-
-
-
-*The new owner accepts the ownership transfer.*
-
-
 ### addTrustedRelayer
 
 ```solidity
@@ -148,23 +137,6 @@ function owner() external view returns (address)
 
 
 *Returns the address of the current owner.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address)
-```
-
-
-
-*Returns the address of the pending owner.*
 
 
 #### Returns
@@ -208,7 +180,7 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 
-*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
 
 #### Parameters
 
@@ -235,23 +207,6 @@ event Initialized(uint8 version)
 | Name | Type | Description |
 |---|---|---|
 | version  | uint8 | undefined |
-
-### OwnershipTransferStarted
-
-```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
 
 ### OwnershipTransferred
 

--- a/docs/lib/Predicate.md
+++ b/docs/lib/Predicate.md
@@ -1,0 +1,274 @@
+# Predicate
+
+
+
+
+
+
+
+
+
+## Methods
+
+### DEPOSIT_BATCH_SIG
+
+```solidity
+function DEPOSIT_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### DEPOSIT_SIG
+
+```solidity
+function DEPOSIT_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### MAP_TOKEN_SIG
+
+```solidity
+function MAP_TOKEN_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### ROLLBACK_SIG
+
+```solidity
+function ROLLBACK_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### WITHDRAW_BATCH_SIG
+
+```solidity
+function WITHDRAW_BATCH_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### WITHDRAW_SIG
+
+```solidity
+function WITHDRAW_SIG() external view returns (bytes32)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes32 | undefined |
+
+### acceptOwnership
+
+```solidity
+function acceptOwnership() external nonpayable
+```
+
+
+
+*The new owner accepts the ownership transfer.*
+
+
+### addTrustedRelayer
+
+```solidity
+function addTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+
+
+*Returns the address of the current owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address)
+```
+
+
+
+*Returns the address of the pending owner.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### removeTrustedRelayer
+
+```solidity
+function removeTrustedRelayer(address relayer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| relayer | address | undefined |
+
+### renounceOwnership
+
+```solidity
+function renounceOwnership() external nonpayable
+```
+
+
+
+*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.*
+
+
+### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable
+```
+
+
+
+*Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one. Can only be called by the current owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newOwner | address | undefined |
+
+
+
+## Events
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+*Triggered when the contract has been initialized or reinitialized.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
+
+### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| previousOwner `indexed` | address | undefined |
+| newOwner `indexed` | address | undefined |
+
+
+

--- a/script/deployment/bridge/DeployRootERC1155Predicate.s.sol
+++ b/script/deployment/bridge/DeployRootERC1155Predicate.s.sol
@@ -17,7 +17,7 @@ abstract contract RootERC1155PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootERC1155Predicate.initialize,
-            (newStateSender, newExitHelper, newChildERC1155Predicate, newChildTokenTemplate)
+            (newStateSender, newExitHelper, newChildERC1155Predicate, newChildTokenTemplate, proxyAdmin)
         );
 
         vm.startBroadcast();

--- a/script/deployment/bridge/DeployRootERC20Predicate.s.sol
+++ b/script/deployment/bridge/DeployRootERC20Predicate.s.sol
@@ -18,7 +18,14 @@ abstract contract RootERC20PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootERC20Predicate.initialize,
-            (newStateSender, newExitHelper, newChildERC20Predicate, newChildTokenTemplate, nativeTokenRootAddress)
+            (
+                newStateSender,
+                newExitHelper,
+                newChildERC20Predicate,
+                newChildTokenTemplate,
+                nativeTokenRootAddress,
+                proxyAdmin
+            )
         );
 
         vm.startBroadcast();

--- a/script/deployment/bridge/DeployRootERC721Predicate.s.sol
+++ b/script/deployment/bridge/DeployRootERC721Predicate.s.sol
@@ -17,7 +17,7 @@ abstract contract RootERC721PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootERC721Predicate.initialize,
-            (newStateSender, newExitHelper, newChildERC721Predicate, newChildTokenTemplate)
+            (newStateSender, newExitHelper, newChildERC721Predicate, newChildTokenTemplate, proxyAdmin)
         );
 
         vm.startBroadcast();

--- a/script/deployment/test/blade/DeployRootMintableERC1155Predicate.s.sol
+++ b/script/deployment/test/blade/DeployRootMintableERC1155Predicate.s.sol
@@ -17,7 +17,7 @@ abstract contract RootMintableERC1155PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootMintableERC1155Predicate.initialize,
-            (newL2StateSender, newStateReceiver, newChildERC1155Predicate, newChildTokenTemplate)
+            (newL2StateSender, newStateReceiver, newChildERC1155Predicate, newChildTokenTemplate, proxyAdmin)
         );
 
         vm.startBroadcast();

--- a/script/deployment/test/blade/DeployRootMintableERC20Predicate.s.sol
+++ b/script/deployment/test/blade/DeployRootMintableERC20Predicate.s.sol
@@ -17,7 +17,7 @@ abstract contract RootMintableERC20PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootMintableERC20Predicate.initialize,
-            (newL2StateSender, newStateReceiver, newChildERC20Predicate, newChildTokenTemplate)
+            (newL2StateSender, newStateReceiver, newChildERC20Predicate, newChildTokenTemplate, proxyAdmin)
         );
 
         vm.startBroadcast();

--- a/script/deployment/test/blade/DeployRootMintableERC721Predicate.s.sol
+++ b/script/deployment/test/blade/DeployRootMintableERC721Predicate.s.sol
@@ -17,7 +17,7 @@ abstract contract RootMintableERC721PredicateDeployer is Script {
     ) internal returns (address logicAddr, address proxyAddr) {
         bytes memory initData = abi.encodeCall(
             RootMintableERC721Predicate.initialize,
-            (newL2StateSender, newStateReceiver, newChildERC721Predicate, newChildTokenTemplate)
+            (newL2StateSender, newStateReceiver, newChildERC721Predicate, newChildTokenTemplate, proxyAdmin)
         );
 
         vm.startBroadcast();

--- a/test/blade/RootMintableERC1155Predicate.test.ts
+++ b/test/blade/RootMintableERC1155Predicate.test.ts
@@ -73,6 +73,7 @@ describe("RootMintableERC1155Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootMintableERC1155Predicate: BAD_INITIALIZATION");
@@ -83,18 +84,21 @@ describe("RootMintableERC1155Predicate", () => {
       l2StateSender.address,
       stateReceiver.address,
       childERC1155Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      accounts[0].address
     );
 
     expect(await rootMintableERC1155Predicate.l2StateSender()).to.equal(l2StateSender.address);
     expect(await rootMintableERC1155Predicate.stateReceiver()).to.equal(stateReceiver.address);
     expect(await rootMintableERC1155Predicate.childERC1155Predicate()).to.equal(childERC1155Predicate);
     expect(await rootMintableERC1155Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootMintableERC1155Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       systemRootMintableERC1155Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -112,7 +116,7 @@ describe("RootMintableERC1155Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       stateReceiverRootMintableERC1155Predicate.onStateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootMintableERC1155Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootMintableERC1155Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/blade/RootMintableERC20Predicate.test.ts
+++ b/test/blade/RootMintableERC20Predicate.test.ts
@@ -90,6 +90,7 @@ describe("RootMintableERC20Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootMintableERC20Predicate: BAD_INITIALIZATION");
@@ -100,18 +101,21 @@ describe("RootMintableERC20Predicate", () => {
       l2StateSender.address,
       stateReceiver.address,
       childERC20Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      accounts[0].address
     );
 
     expect(await rootMintableERC20Predicate.l2StateSender()).to.equal(l2StateSender.address);
     expect(await rootMintableERC20Predicate.stateReceiver()).to.equal(stateReceiver.address);
     expect(await rootMintableERC20Predicate.childERC20Predicate()).to.equal(childERC20Predicate);
     expect(await rootMintableERC20Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootMintableERC20Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       systemRootMintableERC20Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -129,7 +133,7 @@ describe("RootMintableERC20Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       stateReceiverRootMintableERC20Predicate.onStateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootMintableERC20Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootMintableERC20Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/blade/RootMintableERC721Predicate.test.ts
+++ b/test/blade/RootMintableERC721Predicate.test.ts
@@ -72,6 +72,7 @@ describe("RootMintableERC721Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootMintableERC721Predicate: BAD_INITIALIZATION");
@@ -82,18 +83,21 @@ describe("RootMintableERC721Predicate", () => {
       l2StateSender.address,
       stateReceiver.address,
       childERC721Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      accounts[0].address
     );
 
     expect(await rootMintableERC721Predicate.l2StateSender()).to.equal(l2StateSender.address);
     expect(await rootMintableERC721Predicate.stateReceiver()).to.equal(stateReceiver.address);
     expect(await rootMintableERC721Predicate.childERC721Predicate()).to.equal(childERC721Predicate);
     expect(await rootMintableERC721Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootMintableERC721Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       systemRootMintableERC721Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -111,7 +115,7 @@ describe("RootMintableERC721Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       stateReceiverRootMintableERC721Predicate.onStateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootMintableERC721Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootMintableERC721Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/bridge/RootERC1155Predicate.test.ts
+++ b/test/bridge/RootERC1155Predicate.test.ts
@@ -61,6 +61,7 @@ describe("RootERC1155Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootERC1155Predicate: BAD_INITIALIZATION");
@@ -71,18 +72,21 @@ describe("RootERC1155Predicate", () => {
       stateSender.address,
       exitHelper.address,
       childERC1155Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      accounts[0].address
     );
 
     expect(await rootERC1155Predicate.stateSender()).to.equal(stateSender.address);
     expect(await rootERC1155Predicate.exitHelper()).to.equal(exitHelper.address);
     expect(await rootERC1155Predicate.childERC1155Predicate()).to.equal(childERC1155Predicate);
     expect(await rootERC1155Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootERC1155Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       rootERC1155Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -100,7 +104,7 @@ describe("RootERC1155Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       exitHelperRootERC1155Predicate.onL2StateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootERC1155Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootERC1155Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/bridge/RootERC20Predicate.test.ts
+++ b/test/bridge/RootERC20Predicate.test.ts
@@ -61,6 +61,7 @@ describe("RootERC20Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootERC20Predicate: BAD_INITIALIZATION");
@@ -73,7 +74,8 @@ describe("RootERC20Predicate", () => {
       exitHelper.address,
       childERC20Predicate,
       childTokenTemplate.address,
-      nativeTokenRootAddress
+      nativeTokenRootAddress,
+      accounts[0].address
     );
 
     expect(await rootERC20Predicate.stateSender()).to.equal(stateSender.address);
@@ -83,11 +85,13 @@ describe("RootERC20Predicate", () => {
     expect(await rootERC20Predicate.rootTokenToChildToken(nativeTokenRootAddress)).to.equal(
       "0x0000000000000000000000000000000000001010"
     );
+    expect(await rootERC20Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       rootERC20Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -106,7 +110,7 @@ describe("RootERC20Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       exitHelperRootERC20Predicate.onL2StateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootERC20Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootERC20Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/bridge/RootERC721Predicate.test.ts
+++ b/test/bridge/RootERC721Predicate.test.ts
@@ -60,6 +60,7 @@ describe("RootERC721Predicate", () => {
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000"
       )
     ).to.be.revertedWith("RootERC721Predicate: BAD_INITIALIZATION");
@@ -70,18 +71,21 @@ describe("RootERC721Predicate", () => {
       stateSender.address,
       exitHelper.address,
       childERC721Predicate,
-      childTokenTemplate.address
+      childTokenTemplate.address,
+      accounts[0].address
     );
 
     expect(await rootERC721Predicate.stateSender()).to.equal(stateSender.address);
     expect(await rootERC721Predicate.exitHelper()).to.equal(exitHelper.address);
     expect(await rootERC721Predicate.childERC721Predicate()).to.equal(childERC721Predicate);
     expect(await rootERC721Predicate.childTokenTemplate()).to.equal(childTokenTemplate.address);
+    expect(await rootERC721Predicate.owner()).to.equal(accounts[0].address);
   });
 
   it("fail reinitialization", async () => {
     await expect(
       rootERC721Predicate.initialize(
+        "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
         "0x0000000000000000000000000000000000000000",
@@ -99,7 +103,7 @@ describe("RootERC721Predicate", () => {
   it("withdraw tokens fail: only child predicate", async () => {
     await expect(
       exitHelperRootERC721Predicate.onL2StateReceive(0, ethers.Wallet.createRandom().address, "0x00")
-    ).to.be.revertedWith("RootERC721Predicate: ONLY_CHILD_PREDICATE");
+    ).to.be.revertedWith("RootERC721Predicate: ONLY_CHILD_PREDICATE_OR_TRUSTED_RELAYER");
   });
 
   it("withdraw tokens fail: invalid signature", async () => {

--- a/test/forge/bridge/BladeManager.t.sol
+++ b/test/forge/bridge/BladeManager.t.sol
@@ -73,7 +73,8 @@ contract BladeManager_PremineInitialized is Initialized {
             address(new ExitHelper()),
             childERC20Predicate,
             childTokenTemplate,
-            address(token)
+            address(token),
+            bob
         );
     }
 

--- a/test/forge/bridge/deployment/DeployChildMintableERC1155Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployChildMintableERC1155Predicate.t.sol
@@ -61,22 +61,10 @@ contract DeployChildMintableERC1155PredicateTest is Test {
             newChildTokenTemplate
         );
 
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC1155Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC1155Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC1155Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newRootERC1155Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC1155Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsChildMintableERC1155Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsChildMintableERC1155Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsChildMintableERC1155Predicate.rootERC1155Predicate(), newRootERC1155Predicate);
+        assertEq(proxyAsChildMintableERC1155Predicate.childTokenTemplate(), newChildTokenTemplate);
     }
 
     function testLogicChange() public {

--- a/test/forge/bridge/deployment/DeployChildMintableERC20Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployChildMintableERC20Predicate.t.sol
@@ -61,22 +61,10 @@ contract DeployChildMintableERC20PredicateTest is Test {
             newChildTokenTemplate
         );
 
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC20Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC20Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC20Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newRootERC20Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC20Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsChildMintableERC20Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsChildMintableERC20Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsChildMintableERC20Predicate.rootERC20Predicate(), newRootERC20Predicate);
+        assertEq(proxyAsChildMintableERC20Predicate.childTokenTemplate(), newChildTokenTemplate);
     }
 
     function testLogicChange() public {

--- a/test/forge/bridge/deployment/DeployChildMintableERC721Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployChildMintableERC721Predicate.t.sol
@@ -61,22 +61,10 @@ contract DeployChildMintableERC721PredicateTest is Test {
             newChildTokenTemplate
         );
 
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC721Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC721Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC721Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newRootERC721Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsChildMintableERC721Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsChildMintableERC721Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsChildMintableERC721Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsChildMintableERC721Predicate.rootERC721Predicate(), newRootERC721Predicate);
+        assertEq(proxyAsChildMintableERC721Predicate.childTokenTemplate(), newChildTokenTemplate);
     }
 
     function testLogicChange() public {

--- a/test/forge/bridge/deployment/DeployRootERC1155Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployRootERC1155Predicate.t.sol
@@ -62,22 +62,10 @@ contract DeployRootERC1155PredicateTest is Test {
             proxyAdmin
         );
 
-        assertEq(
-            vm.load(address(proxyAsRootERC1155Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC1155Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC1155Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildERC1155Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC1155Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsRootERC1155Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsRootERC1155Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsRootERC1155Predicate.childERC1155Predicate(), newChildERC1155Predicate);
+        assertEq(proxyAsRootERC1155Predicate.childTokenTemplate(), newChildTokenTemplate);
     }
 
     function testLogicChange() public {

--- a/test/forge/bridge/deployment/DeployRootERC20Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployRootERC20Predicate.t.sol
@@ -62,7 +62,8 @@ contract DeployRootERC20PredicateTest is Test {
             newExitHelper,
             newChildERC20Predicate,
             newChildTokenTemplate,
-            nativeTokenRootAddress
+            nativeTokenRootAddress,
+            proxyAdmin
         );
 
         assertEq(

--- a/test/forge/bridge/deployment/DeployRootERC20Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployRootERC20Predicate.t.sol
@@ -66,22 +66,10 @@ contract DeployRootERC20PredicateTest is Test {
             proxyAdmin
         );
 
-        assertEq(
-            vm.load(address(proxyAsRootERC20Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC20Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC20Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildERC20Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC20Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsRootERC20Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsRootERC20Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsRootERC20Predicate.childERC20Predicate(), newChildERC20Predicate);
+        assertEq(proxyAsRootERC20Predicate.childTokenTemplate(), newChildTokenTemplate);
         assertEq(
             proxyAsRootERC20Predicate.rootTokenToChildToken(nativeTokenRootAddress),
             address(0x0000000000000000000000000000000000001010)

--- a/test/forge/bridge/deployment/DeployRootERC721Predicate.t copy.sol
+++ b/test/forge/bridge/deployment/DeployRootERC721Predicate.t copy.sol
@@ -58,7 +58,8 @@ contract DeployRootERC1155PredicateTest is Test {
             newStateSender,
             newExitHelper,
             newChildERC1155Predicate,
-            newChildTokenTemplate
+            newChildTokenTemplate,
+            proxyAdmin
         );
 
         assertEq(

--- a/test/forge/bridge/deployment/DeployRootERC721Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployRootERC721Predicate.t.sol
@@ -58,7 +58,8 @@ contract DeployRootERC721PredicateTest is Test {
             newStateSender,
             newExitHelper,
             newChildERC721Predicate,
-            newChildTokenTemplate
+            newChildTokenTemplate,
+            proxyAdmin
         );
 
         assertEq(

--- a/test/forge/bridge/deployment/DeployRootERC721Predicate.t.sol
+++ b/test/forge/bridge/deployment/DeployRootERC721Predicate.t.sol
@@ -62,22 +62,10 @@ contract DeployRootERC721PredicateTest is Test {
             proxyAdmin
         );
 
-        assertEq(
-            vm.load(address(proxyAsRootERC721Predicate), bytes32(uint(0))),
-            bytes32(bytes.concat(hex"00000000000000000000", abi.encodePacked(newStateSender), hex"0001"))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC721Predicate), bytes32(uint(1))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newExitHelper)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC721Predicate), bytes32(uint(2))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildERC721Predicate)))
-        );
-        assertEq(
-            vm.load(address(proxyAsRootERC721Predicate), bytes32(uint(3))),
-            bytes32(bytes.concat(hex"000000000000000000000000", abi.encodePacked(newChildTokenTemplate)))
-        );
+        assertEq(address(proxyAsRootERC721Predicate.stateSender()), newStateSender);
+        assertEq(proxyAsRootERC721Predicate.exitHelper(), newExitHelper);
+        assertEq(proxyAsRootERC721Predicate.childERC721Predicate(), newChildERC721Predicate);
+        assertEq(proxyAsRootERC721Predicate.childTokenTemplate(), newChildTokenTemplate);
     }
 
     function testLogicChange() public {


### PR DESCRIPTION
This PR implements a rollback mechanism on predicates. This is essential to unblock stuck tokens on each side if a transaction fails on the other side.

All predicates on the token origin side now inherit `Predicate` abstract contract that is ownable, and their `initialize` functions are expanded with the address of the owner account. Owner account can add or remove `trusted relayer` addresses, which can detect a failed bridge transaction, and will automatically rollback it on the starting chain so that the tokens can be unblocked.

Basically, the issue was that an account on L1, can send a deposit to L2, which will first block its tokens on the L1 root predicate, and then will send a state sync event to L2. That state sync event failed on L2 for some reason, meaning the tokens on L1 got stuck without the way of unblocking them, and withdrawing them back to the sender account.

Now, contracts provide a way to unblock it, by resending the same state sync event back to the L1 so that the tokens can be withdrawn, and this is done by the trusted relayers on L2.