### PR TITLE
Add `commitBatches` function to `BridgeStorage`

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -46,11 +46,16 @@ contract BridgeStorage is ValidatorSetStorage {
         bytes memory hash = abi.encode(keccak256(abi.encode(newBatches)));
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signature, bitmap);
 
+        uint256 counter = batchCounter;
         for (uint256 i = 0; i < newBatches.length; i++) {
             _verifyBatch(newBatches[i]);
 
-            batches[batchCounter++] = newBatches[i];
-            emit NewBatch(batchCounter - 1);
+            batches[counter] = newBatches[i];
+            emit NewBatch(counter);
+
+            unchecked {
+                ++counter;
+            }
         }
     }
 

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -255,6 +255,24 @@ function commitBatch(BridgeMessageBatch batch, uint256[2] signature, bytes bitma
 | signature | uint256[2] | undefined |
 | bitmap | bytes | undefined |
 
+### commitBatches
+
+```solidity
+function commitBatches(BridgeMessageBatch[] newBatches, uint256[2] signature, bytes bitmap) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newBatches | BridgeMessageBatch[] | undefined |
+| signature | uint256[2] | undefined |
+| bitmap | bytes | undefined |
+
 ### commitValidatorSet
 
 ```solidity


### PR DESCRIPTION
This PR adds a `commitBatches` function to `BridgeStorage` contract, which stores an array of batches.

This PR considers that the entire array of batches passed, is signed by the active validators (in regards to `commitBatch` which considers a single batch to be signed).

**TODO**
Add some tests for the function.