### PR TITLE
Remove unused VALIDATOR_PKCHECK_PRECOMPILE address

### DIFF
--- a/contracts/blade/System.sol
+++ b/contracts/blade/System.sol
@@ -7,7 +7,6 @@ contract System {
     // pre-compiled contracts
     // slither-disable too-many-digits
     address public constant NATIVE_TRANSFER_PRECOMPILE = 0x0000000000000000000000000000000000002020;
-    address public constant VALIDATOR_PKCHECK_PRECOMPILE = 0x0000000000000000000000000000000000002030;
     address public constant ALLOWLIST_PRECOMPILE = 0x0200000000000000000000000000000000000004;
     address public constant BLOCKLIST_PRECOMPILE = 0x0300000000000000000000000000000000000004;
 
@@ -16,7 +15,6 @@ contract System {
 
     // pre-compiled gas consumption
     uint256 public constant NATIVE_TRANSFER_PRECOMPILE_GAS = 21000;
-    uint256 public constant VALIDATOR_PKCHECK_PRECOMPILE_GAS = 150000;
     uint256 public constant READ_ADDRESSLIST_GAS = 5000;
 
     // genesis contracts

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### batchCounter
 
 ```solidity

--- a/docs/blade/ChildERC1155PredicateAccessList.md
+++ b/docs/blade/ChildERC1155PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/ChildERC20Predicate.md
+++ b/docs/blade/ChildERC20Predicate.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/ChildERC20PredicateAccessList.md
+++ b/docs/blade/ChildERC20PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/ChildERC721PredicateAccessList.md
+++ b/docs/blade/ChildERC721PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -146,40 +146,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### bls
 
 ```solidity

--- a/docs/blade/NativeERC20.md
+++ b/docs/blade/NativeERC20.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### allowance
 
 ```solidity

--- a/docs/blade/NativeERC20Mintable.md
+++ b/docs/blade/NativeERC20Mintable.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### acceptOwnership
 
 ```solidity

--- a/docs/blade/RootMintableERC1155PredicateAccessList.md
+++ b/docs/blade/RootMintableERC1155PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/RootMintableERC20PredicateAccessList.md
+++ b/docs/blade/RootMintableERC20PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/RootMintableERC721PredicateAccessList.md
+++ b/docs/blade/RootMintableERC721PredicateAccessList.md
@@ -180,40 +180,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### WITHDRAW_BATCH_SIG
 
 ```solidity

--- a/docs/blade/System.md
+++ b/docs/blade/System.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 
 
 

--- a/docs/blade/ValidatorSetStorage.md
+++ b/docs/blade/ValidatorSetStorage.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### bls
 
 ```solidity

--- a/docs/blade/validator/EpochManager.md
+++ b/docs/blade/validator/EpochManager.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### commitEpoch
 
 ```solidity

--- a/docs/lib/AccessList.md
+++ b/docs/lib/AccessList.md
@@ -129,40 +129,6 @@ function SYSTEM() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### VALIDATOR_PKCHECK_PRECOMPILE
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-### VALIDATOR_PKCHECK_PRECOMPILE_GAS
-
-```solidity
-function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### acceptOwnership
 
 ```solidity


### PR DESCRIPTION
The validator public key check precompile is unused, so removing the constants from the contracts.