### PR TITLE
Fix validator set and batch storage

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -13,7 +13,8 @@ contract BridgeStorage is ValidatorSetStorage {
     /// @custom:security write-protection="onlySystemCall()"
     uint256 public validatorSetCounter;
 
-    event NewBatch(uint256 id);
+    event NewBatch(uint256 indexed id);
+    event NewValidatorSetStored(uint256 indexed id);
 
     /**
      * @notice commits new validator set
@@ -38,6 +39,8 @@ contract BridgeStorage is ValidatorSetStorage {
                 ++i;
             }
         }
+
+        emit NewValidatorSetStored(validatorSetCounter);
 
         validatorSetCounter++;
     }

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -48,6 +48,8 @@ contract BridgeStorage is ValidatorSetStorage {
     /**
      * @notice commits new batch
      * @param batch new batch
+     * @param signature aggregated signature of validators that signed the new batch
+     * @param bitmap bitmap of which validators signed the message
      */
     function commitBatch(
         BridgeMessageBatch calldata batch,

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -38,16 +38,8 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         Validator[] calldata newValidatorSet,
         uint256[2] calldata signature,
         bytes calldata bitmap
-    ) external onlySystemCall {
-        require(newValidatorSet.length > 0, "EMPTY_VALIDATOR_SET");
-
-        bytes memory hash = abi.encode(keccak256(abi.encode(newValidatorSet)));
-
-        verifySignature(bls.hashToPoint(DOMAIN_VALIDATOR_SET, hash), signature, bitmap);
-
-        _setNewValidatorSet(newValidatorSet);
-
-        emit NewValidatorSet(newValidatorSet);
+    ) external virtual onlySystemCall {
+        _commitValidatorSet(newValidatorSet, signature, bitmap);
     }
 
     /**
@@ -135,5 +127,21 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
 
         // Get the value of the bit at the given 'index' in a byte.
         return uint8(bitmap[byteNumber]) & (1 << bitNumber) > 0;
+    }
+
+    function _commitValidatorSet(
+        Validator[] calldata newValidatorSet,
+        uint256[2] calldata signature,
+        bytes calldata bitmap
+    ) internal {
+        require(newValidatorSet.length > 0, "EMPTY_VALIDATOR_SET");
+
+        bytes memory hash = abi.encode(keccak256(abi.encode(newValidatorSet)));
+
+        verifySignature(bls.hashToPoint(DOMAIN_VALIDATOR_SET, hash), signature, bitmap);
+
+        _setNewValidatorSet(newValidatorSet);
+
+        emit NewValidatorSet(newValidatorSet);
     }
 }

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -129,6 +129,14 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         return uint8(bitmap[byteNumber]) & (1 << bitNumber) > 0;
     }
 
+    /**
+     * @notice Commits a new validator set by verifying its signature and setting it in the storage.
+     * @dev This function requires that the new validator set is non-empty and verifies its signature before updating the validator set.
+     * @param newValidatorSet The array of validators to be set as the new validator set
+     * @param signature The aggregated signature of the validators that signed the new validator set
+     * @param bitmap The bitmap representing which validators signed the new validator set
+     * Emits a `NewValidatorSet` event after successfully setting the new validator set.
+     */
     function _commitValidatorSet(
         Validator[] calldata newValidatorSet,
         uint256[2] calldata signature,

--- a/contracts/interfaces/blade/IValidatorSetStorage.sol
+++ b/contracts/interfaces/blade/IValidatorSetStorage.sol
@@ -44,6 +44,28 @@ struct BridgeMessageBatch {
     uint256 destinationChainId;
 }
 
+/**
+ * @param batch batch that is signed
+ * @param signature aggregated signature of validators that signed the batch
+ * @param bitmap bitmap of which validators signed the message
+ */
+struct SignedBridgeMessageBatch {
+    BridgeMessageBatch batch;
+    uint256[2] signature;
+    bytes bitmap;
+}
+
+/**
+ * @param newValidatorSet new validator set
+ * @param signature aggregated signature of validators that signed the new validator set
+ * @param bitmap bitmap of which validators signed the message
+ */
+struct SignedValidatorSet {
+    Validator[] newValidatorSet;
+    uint256[2] signature;
+    bytes bitmap;
+}
+
 interface IValidatorSetStorage {
     event NewValidatorSet(Validator[] newValidatorSet);
 

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -149,7 +149,7 @@ function batchCounter() external view returns (uint256)
 ### batches
 
 ```solidity
-function batches(uint256) external view returns (uint256 sourceChainId, uint256 destinationChainId)
+function batches(uint256) external view returns (struct BridgeMessageBatch batch, bytes bitmap)
 ```
 
 
@@ -166,8 +166,8 @@ function batches(uint256) external view returns (uint256 sourceChainId, uint256 
 
 | Name | Type | Description |
 |---|---|---|
-| sourceChainId | uint256 | undefined |
-| destinationChainId | uint256 | undefined |
+| batch | BridgeMessageBatch | undefined |
+| bitmap | bytes | undefined |
 
 ### bls
 
@@ -237,6 +237,28 @@ function commitValidatorSet(Validator[] newValidatorSet, uint256[2] signature, b
 |---|---|---|
 | newValidatorSet | Validator[] | undefined |
 | signature | uint256[2] | undefined |
+| bitmap | bytes | undefined |
+
+### commitedValidatorSets
+
+```solidity
+function commitedValidatorSets(uint256) external view returns (bytes bitmap)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
 | bitmap | bytes | undefined |
 
 ### currentValidatorSet
@@ -362,6 +384,23 @@ function lastCommittedInternal(uint256) external view returns (uint256)
 
 ```solidity
 function totalVotingPower() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### validatorSetCounter
+
+```solidity
+function validatorSetCounter() external view returns (uint256)
 ```
 
 


### PR DESCRIPTION
This PR fixes storing of signatures and bitmaps of signed validator sets and batches on `BridgeStorage` contract.