### PR TITLE
Export get committed functions

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -95,6 +95,22 @@ contract BridgeStorage is ValidatorSetStorage {
         }
     }
 
+    /**
+     * @notice Returns the committed batch based on provided id
+     * @param id batch id
+     */
+    function getCommittedBatch(uint256 id) external view returns (SignedBridgeMessageBatch memory) {
+        return batches[id];
+    }
+
+    /**
+     * @notice Returns the committed validator set based on provided id
+     * @param id validator set id
+     */
+    function getCommittedValidatorSet(uint256 id) external view returns (SignedValidatorSet memory) {
+        return commitedValidatorSets[id];
+    }
+
     // slither-disable-next-line unused-state,naming-convention
     uint256[50] private __gap;
 }

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -318,6 +318,50 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### getCommittedBatch
+
+```solidity
+function getCommittedBatch(uint256 id) external view returns (struct SignedBridgeMessageBatch)
+```
+
+Returns the committed batch based on provided id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | batch id |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | SignedBridgeMessageBatch | undefined |
+
+### getCommittedValidatorSet
+
+```solidity
+function getCommittedValidatorSet(uint256 id) external view returns (struct SignedValidatorSet)
+```
+
+Returns the committed validator set based on provided id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | validator set id |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | SignedValidatorSet | undefined |
+
 ### initialize
 
 ```solidity


### PR DESCRIPTION
We need to export two functions for relayer:
`getCommittedBatch` - returns the committed batch by batch id.
`getCommittedValidatorSet` - returns the committed validator set.

This is needed because we can not use the exported mappings since solidity compiler does not generate the signature field in the `Signed` structures if that struct is not used in any function. This is done because of solidity optimizations if that structure is not used in any function.