### PR TITLE
OnStateReceive handle rollback

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -82,12 +82,14 @@ contract BridgeStorage is ValidatorSetStorage {
     function _verifyBatch(SignedBridgeMessageBatch calldata batch) private {
         require(batch.rootHash != bytes32(0), "EMPTY_BATCH");
 
-        if (batch.sourceChainId == block.chainid) {
-            require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
-            lastCommittedInternal[batch.destinationChainId] = batch.endId;
-        } else {
-            require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
-            lastCommitted[batch.sourceChainId] = batch.endId;
+        if (!batch.isRollback) {
+            if (batch.sourceChainId == block.chainid) {
+                require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
+                lastCommittedInternal[batch.destinationChainId] = batch.endId;
+            } else {
+                require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
+                lastCommitted[batch.sourceChainId] = batch.endId;
+            }
         }
     }
 

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -88,14 +88,14 @@ contract BridgeStorage is ValidatorSetStorage {
         }
     }
 
-    function _verifyRegularBatch(SignedBridgeMessageBatch calldata batch) private{
-            if (batch.sourceChainId == block.chainid) {
-                require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
-                lastCommittedInternal[batch.destinationChainId] = batch.endId;
-            } else {
-                require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
-                lastCommitted[batch.sourceChainId] = batch.endId;
-            }
+    function _verifyRegularBatch(SignedBridgeMessageBatch calldata batch) private {
+        if (batch.sourceChainId == block.chainid) {
+            require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
+            lastCommittedInternal[batch.destinationChainId] = batch.endId;
+        } else {
+            require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
+            lastCommitted[batch.sourceChainId] = batch.endId;
+        }
     }
 
     /**

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -50,7 +50,11 @@ contract BridgeStorage is ValidatorSetStorage {
      * @param batch new batch
      */
     function commitBatch(SignedBridgeMessageBatch calldata batch) external onlySystemCall {
-        _verifyBatch(batch);
+        if (batch.isRollback) {
+            _verifyRollbackBatch(batch);
+        } else {
+            _verifyRegularBatch(batch);
+        }
 
         bytes memory hash = abi.encode(
             keccak256(
@@ -76,19 +80,12 @@ contract BridgeStorage is ValidatorSetStorage {
     }
 
     /**
-     * @notice Internal function that verifies the batch
+     * @notice Internal function that verifies the regular batch
      * @param batch batch to verify
      */
-    function _verifyBatch(SignedBridgeMessageBatch calldata batch) private {
+    function _verifyRegularBatch(SignedBridgeMessageBatch calldata batch) private {
         require(batch.rootHash != bytes32(0), "EMPTY_BATCH");
         require(batch.sourceChainId != batch.destinationChainId, "sourceChainId and destinationChainId not equal");
-
-        if (!batch.isRollback) {
-            _verifyRegularBatch(batch);
-        }
-    }
-
-    function _verifyRegularBatch(SignedBridgeMessageBatch calldata batch) private {
         if (batch.sourceChainId == block.chainid) {
             require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
             lastCommittedInternal[batch.destinationChainId] = batch.endId;
@@ -96,6 +93,15 @@ contract BridgeStorage is ValidatorSetStorage {
             require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
             lastCommitted[batch.sourceChainId] = batch.endId;
         }
+    }
+
+    /**
+     * @notice Internal function that verifies the rollback batch
+     * @param batch batch to verify
+     */
+    function _verifyRollbackBatch(SignedBridgeMessageBatch calldata batch) private {
+        require(batch.rootHash != bytes32(0), "EMPTY_BATCH");
+        require(batch.sourceChainId != batch.destinationChainId, "sourceChainId and destinationChainId not equal");
     }
 
     /**

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -81,8 +81,14 @@ contract BridgeStorage is ValidatorSetStorage {
      */
     function _verifyBatch(SignedBridgeMessageBatch calldata batch) private {
         require(batch.rootHash != bytes32(0), "EMPTY_BATCH");
+        require(batch.sourceChainId != batch.destinationChainId, "sourceChainId and destinationChainId not equal");
 
         if (!batch.isRollback) {
+            _verifyRegularBatch(batch);
+        }
+    }
+
+    function _verifyRegularBatch(SignedBridgeMessageBatch calldata batch) private{
             if (batch.sourceChainId == block.chainid) {
                 require(lastCommittedInternal[batch.destinationChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
                 lastCommittedInternal[batch.destinationChainId] = batch.endId;
@@ -90,7 +96,6 @@ contract BridgeStorage is ValidatorSetStorage {
                 require(lastCommitted[batch.sourceChainId] + 1 == batch.startId, "INVALID_LAST_COMMITTED");
                 lastCommitted[batch.sourceChainId] = batch.endId;
             }
-        }
     }
 
     /**

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -262,17 +262,16 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         emit ERC1155WithdrawBatch(rootToken, address(childToken), msg.sender, receivers, tokenIds, amounts);
     }
 
-    function _withdrawRollback(bytes calldata data) private{
+    function _withdrawRollback(bytes calldata data) private {
         (address depositToken, address withdrawer, , uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
         );
 
         _depositInternal(depositToken, withdrawer, withdrawer, tokenId, amount);
-
     }
 
-    function _deposit(bytes calldata data) private{
+    function _deposit(bytes calldata data) private {
         (address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
@@ -281,7 +280,13 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         _depositInternal(depositToken, depositor, receiver, tokenId, amount);
     }
 
-    function _depositInternal(address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) private {
+    function _depositInternal(
+        address depositToken,
+        address depositor,
+        address receiver,
+        uint256 tokenId,
+        uint256 amount
+    ) private {
         IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");
@@ -301,23 +306,21 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         emit ERC1155Deposit(depositToken, address(childToken), depositor, receiver, tokenId, amount);
     }
 
-    function _withdrawBatchRollback(bytes calldata data) private{
-        (, address depositToken, address withdrawer, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
-            data,
-            (bytes32, address, address, address[], uint256[], uint256[])
-        );
+    function _withdrawBatchRollback(bytes calldata data) private {
+        (, address depositToken, address withdrawer, , uint256[] memory tokenIds, uint256[] memory amounts) = abi
+            .decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
 
         address[] memory withdrawers = new address[](tokenIds.length);
 
-        for(uint256 i=0; i<tokenIds.length; i++){
+        for (uint256 i = 0; i < tokenIds.length; i++) {
             withdrawers[i] = withdrawer;
         }
 
         _depositBatchInternal(depositToken, withdrawer, withdrawers, tokenIds, amounts);
     }
 
-    function _depositBatch(bytes calldata data) private{
-                (
+    function _depositBatch(bytes calldata data) private {
+        (
             ,
             address depositToken,
             address depositor,
@@ -328,9 +331,14 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
 
         _depositBatchInternal(depositToken, depositor, receivers, tokenIds, amounts);
     }
-    
 
-    function _depositBatchInternal(address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds, uint256[] memory amounts) private {
+    function _depositBatchInternal(
+        address depositToken,
+        address depositor,
+        address[] memory receivers,
+        uint256[] memory tokenIds,
+        uint256[] memory amounts
+    ) private {
         IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -113,11 +113,11 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _depositRollback(data[32:]);
+            _withdrawRollback(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
-            _depositBatchRollback(data);
+            _withdrawBatchRollback(data);
             _afterTokenDeposit();
         } else {
             revert("ChildERC1155Predicate: INVALID_SIGNATURE");
@@ -262,69 +262,26 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         emit ERC1155WithdrawBatch(rootToken, address(childToken), msg.sender, receivers, tokenIds, amounts);
     }
 
-    function _deposit(bytes calldata data) private {
+    function _withdrawRollback(bytes calldata data) private{
+        (address depositToken, address withdrawer, , uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
+
+        _depositInternal(depositToken, withdrawer, withdrawer, tokenId, amount);
+
+    }
+
+    function _deposit(bytes calldata data) private{
         (address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
         );
 
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, receiver, tokenId, amount);
-        // slither-disable-next-line reentrancy-events
-        emit ERC1155Deposit(depositToken, address(childToken), depositor, receiver, tokenId, amount);
+        _depositInternal(depositToken, depositor, receiver, tokenId, amount);
     }
 
-    function _depositRollback(bytes calldata data) private {
-        (address depositToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256, uint256)
-        );
-
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, depositor, tokenId, amount);
-    }
-
-    function _depositInternal(address childToken, address receiver, uint256 tokenId, uint256 amount) private {
-        require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
-    }
-
-    function _depositBatch(bytes calldata data) private {
-        (
-            ,
-            address depositToken,
-            address depositor,
-            address[] memory receivers,
-            uint256[] memory tokenIds,
-            uint256[] memory amounts
-        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
-
-        address childToken = _getChildToken(depositToken);
-
-        require(
-            IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
-            "ChildERC1155Predicate: MINT_FAILED"
-        );
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC1155DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds, amounts);
-    }
-
-    function _depositBatchRollback(bytes calldata data) private {
-        (, address depositToken, address depositor, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
-            data,
-            (bytes32, address, address, address[], uint256[], uint256[])
-        );
-
-        address childToken = _getChildToken(depositToken);
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            _depositInternal(childToken, depositor, tokenIds[i], amounts[i]);
-        }
-    }
-
-    function _getChildToken(address depositToken) private view returns (address) {
+    function _depositInternal(address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) private {
         IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");
@@ -339,8 +296,61 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC1155(childToken).predicate() == address(this));
+        require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
+        // slither-disable-next-line reentrancy-events
+        emit ERC1155Deposit(depositToken, address(childToken), depositor, receiver, tokenId, amount);
+    }
 
-        return address(childToken);
+    function _withdrawBatchRollback(bytes calldata data) private{
+        (, address depositToken, address withdrawer, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[], uint256[])
+        );
+
+        address[] memory withdrawers = new address[](tokenIds.length);
+
+        for(uint256 i=0; i<tokenIds.length; i++){
+            withdrawers[i] = withdrawer;
+        }
+
+        _depositBatchInternal(depositToken, withdrawer, withdrawers, tokenIds, amounts);
+    }
+
+    function _depositBatch(bytes calldata data) private{
+                (
+            ,
+            address depositToken,
+            address depositor,
+            address[] memory receivers,
+            uint256[] memory tokenIds,
+            uint256[] memory amounts
+        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
+
+        _depositBatchInternal(depositToken, depositor, receivers, tokenIds, amounts);
+    }
+    
+
+    function _depositBatchInternal(address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds, uint256[] memory amounts) private {
+        IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
+
+        require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");
+        // a mapped token should always pass specifications
+        assert(_verifyContract(childToken));
+
+        address rootToken = IChildERC1155(childToken).rootToken();
+
+        // a mapped child token should match deposited token
+        assert(rootToken == depositToken);
+        // a mapped token should never have root token unset
+        assert(rootToken != address(0));
+        // a mapped token should never have predicate unset
+        assert(IChildERC1155(childToken).predicate() == address(this));
+        require(
+            IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
+            "ChildERC1155Predicate: MINT_FAILED"
+        );
+        // slither-disable-next-line reentrancy-events
+        emit ERC1155DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds, amounts);
     }
 
     /**

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -88,7 +88,7 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _deposit(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _beforeTokenDeposit();
@@ -113,11 +113,11 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _depositRollback(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
-            _depositBatch(data);
+            _depositBatchRollback(data);
             _afterTokenDeposit();
         } else {
             revert("ChildERC1155Predicate: INVALID_SIGNATURE");
@@ -263,36 +263,36 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
     }
 
     function _deposit(bytes calldata data) private {
-        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi
-            .decode(data, (bytes32, address, address, address, uint256, uint256));
+        (address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
 
-        IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
+        address childToken = _getChildToken(depositToken);
 
-        require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");
-        // a mapped token should always pass specifications
-        assert(_verifyContract(childToken));
-
-        address rootToken = IChildERC1155(childToken).rootToken();
-
-        // a mapped child token should match deposited token
-        assert(rootToken == depositToken);
-        // a mapped token should never have root token unset
-        assert(rootToken != address(0));
-        // a mapped token should never have predicate unset
-        assert(IChildERC1155(childToken).predicate() == address(this));
-
-        if (sig == DEPOSIT_SIG) {
-            require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
-        } else {
-            require(IChildERC1155(childToken).mint(depositor, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
-        }
+        _depositInternal(childToken, receiver, tokenId, amount);
         // slither-disable-next-line reentrancy-events
         emit ERC1155Deposit(depositToken, address(childToken), depositor, receiver, tokenId, amount);
     }
 
+    function _depositRollback(bytes calldata data) private {
+        (address depositToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
+
+        address childToken = _getChildToken(depositToken);
+
+        _depositInternal(childToken, depositor, tokenId, amount);
+    }
+
+    function _depositInternal(address childToken, address receiver, uint256 tokenId, uint256 amount) private {
+        require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
+    }
+
     function _depositBatch(bytes calldata data) private {
         (
-            bytes32 sig,
+            ,
             address depositToken,
             address depositor,
             address[] memory receivers,
@@ -300,6 +300,31 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
             uint256[] memory amounts
         ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
 
+        address childToken = _getChildToken(depositToken);
+
+        require(
+            IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
+            "ChildERC1155Predicate: MINT_FAILED"
+        );
+
+        // slither-disable-next-line reentrancy-events
+        emit ERC1155DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds, amounts);
+    }
+
+    function _depositBatchRollback(bytes calldata data) private {
+        (, address depositToken, address depositor, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[], uint256[])
+        );
+
+        address childToken = _getChildToken(depositToken);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            _depositInternal(childToken, depositor, tokenIds[i], amounts[i]);
+        }
+    }
+
+    function _getChildToken(address depositToken) private view returns (address) {
         IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC1155Predicate: UNMAPPED_TOKEN");
@@ -314,25 +339,8 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC1155(childToken).predicate() == address(this));
-        if (sig == DEPOSIT_BATCH_SIG) {
-            require(
-                IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
-                "ChildERC1155Predicate: MINT_FAILED"
-            );
-        } else {
-            address[] memory depositors = new address[](tokenIds.length);
 
-            for (uint i = 0; i < tokenIds.length; i++) {
-                depositors[i] = depositor;
-            }
-
-            require(
-                IChildERC1155(childToken).mintBatch(depositors, tokenIds, amounts),
-                "ChildERC1155Predicate: MINT_FAILED"
-            );
-        }
-        // slither-disable-next-line reentrancy-events
-        emit ERC1155DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds, amounts);
+        return address(childToken);
     }
 
     /**

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -86,16 +86,39 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         require(msg.sender == address(gateway), "ChildERC1155Predicate: ONLY_GATEWAY");
         require(sender == rootERC1155Predicate, "ChildERC1155Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _beforeTokenDeposit();
-            _deposit(data[32:]);
+            _deposit(data);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _mapToken(data);
+        } else {
+            revert("ChildERC1155Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
+     * @notice Function to be used for token deposits for rollback
+     * @param sender Address of the sender on the child chain
+     * @param data Data sent by the sender
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "ChildERC1155Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "ChildERC1155Predicate: ONLY_CHILD_PREDICATE");
+
+        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+            _beforeTokenDeposit();
+            _deposit(data);
+            _afterTokenDeposit();
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+            _beforeTokenDeposit();
+            _depositBatch(data);
+            _afterTokenDeposit();
         } else {
             revert("ChildERC1155Predicate: INVALID_SIGNATURE");
         }
@@ -240,10 +263,8 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
     }
 
     function _deposit(bytes calldata data) private {
-        (address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256, uint256)
-        );
+        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 tokenId, uint256 amount) = abi
+            .decode(data, (bytes32, address, address, address, uint256, uint256));
 
         IChildERC1155 childToken = IChildERC1155(sourceTokenToDestinationToken[depositToken]);
 
@@ -259,14 +280,19 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC1155(childToken).predicate() == address(this));
-        require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
+
+        if (sig == DEPOSIT_SIG) {
+            require(IChildERC1155(childToken).mint(receiver, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
+        } else {
+            require(IChildERC1155(childToken).mint(depositor, tokenId, amount), "ChildERC1155Predicate: MINT_FAILED");
+        }
         // slither-disable-next-line reentrancy-events
         emit ERC1155Deposit(depositToken, address(childToken), depositor, receiver, tokenId, amount);
     }
 
     function _depositBatch(bytes calldata data) private {
         (
-            ,
+            bytes32 sig,
             address depositToken,
             address depositor,
             address[] memory receivers,
@@ -288,10 +314,23 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC1155(childToken).predicate() == address(this));
-        require(
-            IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
-            "ChildERC1155Predicate: MINT_FAILED"
-        );
+        if (sig == DEPOSIT_BATCH_SIG) {
+            require(
+                IChildERC1155(childToken).mintBatch(receivers, tokenIds, amounts),
+                "ChildERC1155Predicate: MINT_FAILED"
+            );
+        } else {
+            address[] memory depositors = new address[](tokenIds.length);
+
+            for (uint i = 0; i < tokenIds.length; i++) {
+                depositors[i] = depositor;
+            }
+
+            require(
+                IChildERC1155(childToken).mintBatch(depositors, tokenIds, amounts),
+                "ChildERC1155Predicate: MINT_FAILED"
+            );
+        }
         // slither-disable-next-line reentrancy-events
         emit ERC1155DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds, amounts);
     }

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -86,11 +86,11 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
         require(msg.sender == address(gateway), "ChildERC1155Predicate: ONLY_GATEWAY");
         require(sender == rootERC1155Predicate, "ChildERC1155Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
             _deposit(data[32:]);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();

--- a/contracts/blade/ChildERC1155Predicate.sol
+++ b/contracts/blade/ChildERC1155Predicate.sol
@@ -263,12 +263,12 @@ contract ChildERC1155Predicate is IChildERC1155Predicate, Predicate, Initializab
     }
 
     function _withdrawRollback(bytes calldata data) private {
-        (address depositToken, address withdrawer, , uint256 tokenId, uint256 amount) = abi.decode(
+        (address depositToken, address sender, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
         );
 
-        _depositInternal(depositToken, withdrawer, withdrawer, tokenId, amount);
+        _depositInternal(depositToken, receiver, sender, tokenId, amount);
     }
 
     function _deposit(bytes calldata data) private {

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -75,7 +75,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         require(msg.sender == address(gateway), "ChildERC20Predicate: ONLY_GATEWAY");
         require(sender == rootERC20Predicate, "ChildERC20Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
             _deposit(data[32:]);
             _afterTokenDeposit();

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -191,7 +191,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
     }
 
     function _withdrawRollback(bytes calldata data) private {
-        (address depositToken, address sender,address receiver, uint256 amount) = abi.decode(
+        (address depositToken, address sender, address receiver, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
         );

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -190,7 +190,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         emit ERC20Withdraw(rootToken, address(childToken), msg.sender, receiver, amount);
     }
 
-    function _withdrawRollback(bytes calldata data) private{
+    function _withdrawRollback(bytes calldata data) private {
         (address depositToken, address depositor, , uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
@@ -208,7 +208,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         _depositInternal(depositToken, depositor, receiver, amount);
     }
 
-    function _depositInternal(address depositToken, address depositor, address receiver, uint256 amount) private{
+    function _depositInternal(address depositToken, address depositor, address receiver, uint256 amount) private {
         IChildERC20 childToken = IChildERC20(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC20Predicate: UNMAPPED_TOKEN");

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -75,7 +75,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         require(msg.sender == address(gateway), "ChildERC20Predicate: ONLY_GATEWAY");
         require(sender == rootERC20Predicate, "ChildERC20Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _beforeTokenDeposit();
             _deposit(data[32:]);
             _afterTokenDeposit();
@@ -98,7 +98,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _depositRollback(data[32:]);
+            _withdrawRollback(data[32:]);
             _afterTokenDeposit();
         } else {
             revert("ChildERC20Predicate: INVALID_SIGNATURE");
@@ -190,36 +190,25 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         emit ERC20Withdraw(rootToken, address(childToken), msg.sender, receiver, amount);
     }
 
+    function _withdrawRollback(bytes calldata data) private{
+        (address depositToken, address depositor, , uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _depositInternal(depositToken, depositor, depositor, amount);
+    }
+
     function _deposit(bytes calldata data) private {
         (address depositToken, address depositor, address receiver, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, receiver, amount);
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC20Deposit(depositToken, address(childToken), depositor, receiver, amount);
+        _depositInternal(depositToken, depositor, receiver, amount);
     }
 
-    function _depositRollback(bytes calldata data) private {
-        (address depositToken, address depositor, , uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256)
-        );
-
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, depositor, amount);
-    }
-
-    function _depositInternal(address childToken, address receiver, uint256 amount) private {
-        require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
-    }
-
-    function _getChildToken(address depositToken) private view returns (address) {
+    function _depositInternal(address depositToken, address depositor, address receiver, uint256 amount) private{
         IChildERC20 childToken = IChildERC20(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC20Predicate: UNMAPPED_TOKEN");
@@ -234,7 +223,10 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         // a mapped token should never have predicate unset
         assert(IChildERC20(childToken).predicate() == address(this));
 
-        return address(childToken);
+        require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
+
+        // slither-disable-next-line reentrancy-events
+        emit ERC20Deposit(depositToken, address(childToken), depositor, receiver, amount);
     }
 
     /**

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -191,12 +191,12 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
     }
 
     function _withdrawRollback(bytes calldata data) private {
-        (address depositToken, address depositor, , uint256 amount) = abi.decode(
+        (address depositToken, address sender,address receiver, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        _depositInternal(depositToken, depositor, depositor, amount);
+        _depositInternal(depositToken, receiver, sender, amount);
     }
 
     function _deposit(bytes calldata data) private {

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -77,10 +77,29 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
 
         if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _deposit(data[32:]);
+            _deposit(data);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _mapToken(data);
+        } else {
+            revert("ChildERC20Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
+     * @notice Function to be used for token deposits for rollback
+     * @param sender Address of the sender on the child chain
+     * @param data Data sent by the sender
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "ChildERC20Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "ChildERC20Predicate: ONLY_CHILD_PREDICATE");
+
+        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+            _beforeTokenDeposit();
+            _deposit(data);
+            _afterTokenDeposit();
         } else {
             revert("ChildERC20Predicate: INVALID_SIGNATURE");
         }
@@ -172,9 +191,9 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
     }
 
     function _deposit(bytes calldata data) private {
-        (address depositToken, address depositor, address receiver, uint256 amount) = abi.decode(
+        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 amount) = abi.decode(
             data,
-            (address, address, address, uint256)
+            (bytes32, address, address, address, uint256)
         );
 
         IChildERC20 childToken = IChildERC20(sourceTokenToDestinationToken[depositToken]);
@@ -191,7 +210,11 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         // a mapped token should never have predicate unset
         assert(IChildERC20(childToken).predicate() == address(this));
 
-        require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
+        if (sig == DEPOSIT_SIG) {
+            require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
+        } else {
+            require(IChildERC20(childToken).mint(depositor, amount), "ChildERC20Predicate: MINT_FAILED");
+        }
 
         // slither-disable-next-line reentrancy-events
         emit ERC20Deposit(depositToken, address(childToken), depositor, receiver, amount);

--- a/contracts/blade/ChildERC20Predicate.sol
+++ b/contracts/blade/ChildERC20Predicate.sol
@@ -77,7 +77,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
 
         if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _deposit(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _mapToken(data);
@@ -98,7 +98,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _depositRollback(data[32:]);
             _afterTokenDeposit();
         } else {
             revert("ChildERC20Predicate: INVALID_SIGNATURE");
@@ -191,11 +191,35 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
     }
 
     function _deposit(bytes calldata data) private {
-        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 amount) = abi.decode(
+        (address depositToken, address depositor, address receiver, uint256 amount) = abi.decode(
             data,
-            (bytes32, address, address, address, uint256)
+            (address, address, address, uint256)
         );
 
+        address childToken = _getChildToken(depositToken);
+
+        _depositInternal(childToken, receiver, amount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ERC20Deposit(depositToken, address(childToken), depositor, receiver, amount);
+    }
+
+    function _depositRollback(bytes calldata data) private {
+        (address depositToken, address depositor, , uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        address childToken = _getChildToken(depositToken);
+
+        _depositInternal(childToken, depositor, amount);
+    }
+
+    function _depositInternal(address childToken, address receiver, uint256 amount) private {
+        require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
+    }
+
+    function _getChildToken(address depositToken) private view returns (address) {
         IChildERC20 childToken = IChildERC20(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC20Predicate: UNMAPPED_TOKEN");
@@ -210,14 +234,7 @@ contract ChildERC20Predicate is IChildERC20Predicate, Predicate, Initializable, 
         // a mapped token should never have predicate unset
         assert(IChildERC20(childToken).predicate() == address(this));
 
-        if (sig == DEPOSIT_SIG) {
-            require(IChildERC20(childToken).mint(receiver, amount), "ChildERC20Predicate: MINT_FAILED");
-        } else {
-            require(IChildERC20(childToken).mint(depositor, amount), "ChildERC20Predicate: MINT_FAILED");
-        }
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC20Deposit(depositToken, address(childToken), depositor, receiver, amount);
+        return address(childToken);
     }
 
     /**

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -104,8 +104,8 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
      * @dev Can be extended to include other signatures for more functionality
      */
     function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
-        require(msg.sender == address(gateway), "ChildERC20Predicate: ONLY_GATEWAY");
-        require(sender == address(this), "ChildERC20Predicate: ONLY_CHILD_PREDICATE");
+        require(msg.sender == address(gateway), "ChildERC721Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "ChildERC721Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -82,16 +82,37 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         require(msg.sender == address(gateway), "ChildERC721Predicate: ONLY_GATEWAY");
         require(sender == rootERC721Predicate, "ChildERC721Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _beforeTokenDeposit();
-            _deposit(data[32:]);
+            _deposit(data);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
-            _mapToken(data);
+        } else {
+            revert("ChildERC721Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
+     * @notice Function to be used for token deposits for rollback
+     * @param sender Address of the sender on the chain chain
+     * @param data Data sent by the sender
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "ChildERC721Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "ChildERC721Predicate: ONLY_CHILD_PREDICATE");
+
+        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+            _beforeTokenDeposit();
+            _deposit(data);
+            _afterTokenDeposit();
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+            _beforeTokenDeposit();
+            _depositBatch(data);
+            _afterTokenDeposit();
         } else {
             revert("ChildERC721Predicate: INVALID_SIGNATURE");
         }
@@ -223,9 +244,9 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
     }
 
     function _deposit(bytes calldata data) private {
-        (address depositToken, address depositor, address receiver, uint256 tokenId) = abi.decode(
+        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 tokenId) = abi.decode(
             data,
-            (address, address, address, uint256)
+            (bytes32, address, address, address, uint256)
         );
 
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
@@ -242,16 +263,24 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC721(childToken).predicate() == address(this));
-        require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
+
+        if (sig == DEPOSIT_SIG) {
+            require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
+        } else {
+            require(IChildERC721(childToken).mint(depositor, tokenId), "ChildERC721Predicate: MINT_FAILED");
+        }
         // slither-disable-next-line reentrancy-events
         emit ERC721Deposit(depositToken, address(childToken), depositor, receiver, tokenId);
     }
 
     function _depositBatch(bytes calldata data) private {
-        (, address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
-            data,
-            (bytes32, address, address, address[], uint256[])
-        );
+        (
+            bytes32 sig,
+            address depositToken,
+            address depositor,
+            address[] memory receivers,
+            uint256[] memory tokenIds
+        ) = abi.decode(data, (bytes32, address, address, address[], uint256[]));
 
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
 
@@ -267,7 +296,18 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC721(childToken).predicate() == address(this));
-        require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
+        if (sig == DEPOSIT_BATCH_SIG) {
+            require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
+        } else {
+            address[] memory depositors = new address[](tokenIds.length);
+
+            for (uint i = 0; i < tokenIds.length; i++) {
+                depositors[i] = depositor;
+            }
+
+            require(IChildERC721(childToken).mintBatch(depositors, tokenIds), "ChildERC721Predicate: MINT_FAILED");
+        }
+
         // slither-disable-next-line reentrancy-events
         emit ERC721DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds);
     }

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -99,24 +99,20 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
 
     /**
      * @notice Function to be used for token deposits for rollback
-     * @param sender Address of the sender on the chain chain
+     * @param sender Address of the sender on the child chain
      * @param data Data sent by the sender
      * @dev Can be extended to include other signatures for more functionality
      */
     function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
-        require(msg.sender == address(gateway), "ChildERC721Predicate: ONLY_GATEWAY");
-        require(sender == address(this), "ChildERC721Predicate: ONLY_CHILD_PREDICATE");
+        require(msg.sender == address(gateway), "ChildERC20Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "ChildERC20Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _depositRollback(data[32:]);
-            _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
-            _beforeTokenDeposit();
-            _depositBatchRollback(data);
+            _withdrawRollback(data[32:]);
             _afterTokenDeposit();
         } else {
-            revert("ChildERC721Predicate: INVALID_SIGNATURE");
+            revert("ChildERC20Predicate: INVALID_SIGNATURE");
         }
     }
 
@@ -245,63 +241,40 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         emit ERC721WithdrawBatch(rootToken, address(childToken), msg.sender, receivers, tokenIds);
     }
 
+    function _withdrawRollback(bytes calldata data) private{
+        (address depositToken, address depositor, , uint256 tokenId) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _depositInternal(depositToken, depositor, depositor, tokenId);
+    }
+
     function _deposit(bytes calldata data) private {
         (address depositToken, address depositor, address receiver, uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, receiver, tokenId);
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC721Deposit(depositToken, address(childToken), depositor, receiver, tokenId);
+        _depositInternal(depositToken, depositor, receiver, tokenId);
     }
 
-    function _depositRollback(bytes calldata data) private {
-        (address depositToken, address depositor, , uint256 tokenId) = abi.decode(
-            data,
-            (address, address, address, uint256)
-        );
-
-        address childToken = _getChildToken(depositToken);
-
-        _depositInternal(childToken, depositor, tokenId);
-    }
-
-    function _depositInternal(address childToken, address receiver, uint256 tokenId) private {
-        require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
-    }
-
-    function _depositBatch(bytes calldata data) private {
-        (, address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
+    function _withdrawBatchRollbach (bytes calldata data) private {
+        (, address depositToken, address withdrawer, , uint256[] memory tokenIds) = abi.decode(
             data,
             (bytes32, address, address, address[], uint256[])
         );
 
-        address childToken = _getChildToken(depositToken);
+        address[] memory withdrawers = new address[](tokenIds.length);
 
-        require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC721DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds);
-    }
-
-    function _depositBatchRollback(bytes calldata data) private {
-        (, address depositToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
-            data,
-            (bytes32, address, address, address[], uint256[])
-        );
-
-        address childToken = _getChildToken(depositToken);
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            _depositInternal(childToken, depositor, tokenIds[i]);
+        for (uint256 i = 0; i< tokenIds.length; i++){
+            withdrawers[i] = withdrawer;
         }
+
+        _depositBatchInternal(depositToken, withdrawer, withdrawers, tokenIds);
     }
 
-    function _getChildToken(address depositToken) private view returns (address) {
+    function _depositInternal(address depositToken, address depositor, address receiver, uint256 tokenId) private{
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");
@@ -316,8 +289,38 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC721(childToken).predicate() == address(this));
+        require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
+        // slither-disable-next-line reentrancy-events
+        emit ERC721Deposit(depositToken, address(childToken), depositor, receiver, tokenId);
+    }
 
-        return address(childToken);
+    function _depositBatch(bytes calldata data) private {
+        (, address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[])
+        );
+
+        _depositBatchInternal(depositToken, depositor, receivers, tokenIds);
+    }
+
+    function _depositBatchInternal(address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) private{
+        IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
+
+        require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");
+        // a mapped token should always pass specifications
+        assert(_verifyContract(childToken));
+
+        address rootToken = IChildERC721(childToken).rootToken();
+
+        // a mapped token should match deposited token
+        assert(rootToken == depositToken);
+        // a mapped token should never have root token unset
+        assert(rootToken != address(0));
+        // a mapped token should never have predicate unset
+        assert(IChildERC721(childToken).predicate() == address(this));
+        require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
+        // slither-disable-next-line reentrancy-events
+        emit ERC721DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds);
     }
 
     /**

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -90,6 +90,8 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
+            _mapToken(data);
         } else {
             revert("ChildERC721Predicate: INVALID_SIGNATURE");
         }

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -84,7 +84,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _deposit(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _beforeTokenDeposit();
@@ -109,11 +109,11 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
-            _deposit(data);
+            _depositRollback(data[32:]);
             _afterTokenDeposit();
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
-            _depositBatch(data);
+            _depositBatchRollback(data);
             _afterTokenDeposit();
         } else {
             revert("ChildERC721Predicate: INVALID_SIGNATURE");
@@ -246,44 +246,62 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
     }
 
     function _deposit(bytes calldata data) private {
-        (bytes32 sig, address depositToken, address depositor, address receiver, uint256 tokenId) = abi.decode(
+        (address depositToken, address depositor, address receiver, uint256 tokenId) = abi.decode(
             data,
-            (bytes32, address, address, address, uint256)
+            (address, address, address, uint256)
         );
 
-        IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
+        address childToken = _getChildToken(depositToken);
 
-        require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");
-        // a mapped token should always pass specifications
-        assert(_verifyContract(childToken));
+        _depositInternal(childToken, receiver, tokenId);
 
-        address rootToken = IChildERC721(childToken).rootToken();
-
-        // a mapped token should match deposited token
-        assert(rootToken == depositToken);
-        // a mapped token should never have root token unset
-        assert(rootToken != address(0));
-        // a mapped token should never have predicate unset
-        assert(IChildERC721(childToken).predicate() == address(this));
-
-        if (sig == DEPOSIT_SIG) {
-            require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
-        } else {
-            require(IChildERC721(childToken).mint(depositor, tokenId), "ChildERC721Predicate: MINT_FAILED");
-        }
         // slither-disable-next-line reentrancy-events
         emit ERC721Deposit(depositToken, address(childToken), depositor, receiver, tokenId);
     }
 
-    function _depositBatch(bytes calldata data) private {
-        (
-            bytes32 sig,
-            address depositToken,
-            address depositor,
-            address[] memory receivers,
-            uint256[] memory tokenIds
-        ) = abi.decode(data, (bytes32, address, address, address[], uint256[]));
+    function _depositRollback(bytes calldata data) private {
+        (address depositToken, address depositor, , uint256 tokenId) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
 
+        address childToken = _getChildToken(depositToken);
+
+        _depositInternal(childToken, depositor, tokenId);
+    }
+
+    function _depositInternal(address childToken, address receiver, uint256 tokenId) private {
+        require(IChildERC721(childToken).mint(receiver, tokenId), "ChildERC721Predicate: MINT_FAILED");
+    }
+
+    function _depositBatch(bytes calldata data) private {
+        (, address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[])
+        );
+
+        address childToken = _getChildToken(depositToken);
+
+        require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
+
+        // slither-disable-next-line reentrancy-events
+        emit ERC721DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds);
+    }
+
+    function _depositBatchRollback(bytes calldata data) private {
+        (, address depositToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[])
+        );
+
+        address childToken = _getChildToken(depositToken);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            _depositInternal(childToken, depositor, tokenIds[i]);
+        }
+    }
+
+    function _getChildToken(address depositToken) private view returns (address) {
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");
@@ -298,20 +316,8 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         assert(rootToken != address(0));
         // a mapped token should never have predicate unset
         assert(IChildERC721(childToken).predicate() == address(this));
-        if (sig == DEPOSIT_BATCH_SIG) {
-            require(IChildERC721(childToken).mintBatch(receivers, tokenIds), "ChildERC721Predicate: MINT_FAILED");
-        } else {
-            address[] memory depositors = new address[](tokenIds.length);
 
-            for (uint i = 0; i < tokenIds.length; i++) {
-                depositors[i] = depositor;
-            }
-
-            require(IChildERC721(childToken).mintBatch(depositors, tokenIds), "ChildERC721Predicate: MINT_FAILED");
-        }
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC721DepositBatch(depositToken, address(childToken), depositor, receivers, tokenIds);
+        return address(childToken);
     }
 
     /**

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -86,7 +86,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
             _beforeTokenDeposit();
             _deposit(data[32:]);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32])== WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -111,8 +111,12 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
             _beforeTokenDeposit();
             _withdrawRollback(data[32:]);
             _afterTokenDeposit();
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG){
+            _beforeTokenDeposit();
+            _withdrawBatchRollback(data);
+            _afterTokenDeposit();
         } else {
-            revert("ChildERC20Predicate: INVALID_SIGNATURE");
+            revert("ChildERC721Predicate: INVALID_SIGNATURE");
         }
     }
 
@@ -242,12 +246,12 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
     }
 
     function _withdrawRollback(bytes calldata data) private {
-        (address depositToken, address depositor, , uint256 tokenId) = abi.decode(
+        (address depositToken, address sender, address receiver, uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        _depositInternal(depositToken, depositor, depositor, tokenId);
+        _depositInternal(depositToken, receiver, sender, tokenId);
     }
 
     function _deposit(bytes calldata data) private {
@@ -259,7 +263,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         _depositInternal(depositToken, depositor, receiver, tokenId);
     }
 
-    function _withdrawBatchRollbach(bytes calldata data) private {
+    function _withdrawBatchRollback(bytes calldata data) private {
         (, address depositToken, address withdrawer, , uint256[] memory tokenIds) = abi.decode(
             data,
             (bytes32, address, address, address[], uint256[])

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -241,7 +241,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         emit ERC721WithdrawBatch(rootToken, address(childToken), msg.sender, receivers, tokenIds);
     }
 
-    function _withdrawRollback(bytes calldata data) private{
+    function _withdrawRollback(bytes calldata data) private {
         (address depositToken, address depositor, , uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
@@ -259,7 +259,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         _depositInternal(depositToken, depositor, receiver, tokenId);
     }
 
-    function _withdrawBatchRollbach (bytes calldata data) private {
+    function _withdrawBatchRollbach(bytes calldata data) private {
         (, address depositToken, address withdrawer, , uint256[] memory tokenIds) = abi.decode(
             data,
             (bytes32, address, address, address[], uint256[])
@@ -267,14 +267,14 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
 
         address[] memory withdrawers = new address[](tokenIds.length);
 
-        for (uint256 i = 0; i< tokenIds.length; i++){
+        for (uint256 i = 0; i < tokenIds.length; i++) {
             withdrawers[i] = withdrawer;
         }
 
         _depositBatchInternal(depositToken, withdrawer, withdrawers, tokenIds);
     }
 
-    function _depositInternal(address depositToken, address depositor, address receiver, uint256 tokenId) private{
+    function _depositInternal(address depositToken, address depositor, address receiver, uint256 tokenId) private {
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");
@@ -303,7 +303,12 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         _depositBatchInternal(depositToken, depositor, receivers, tokenIds);
     }
 
-    function _depositBatchInternal(address depositToken, address depositor, address[] memory receivers, uint256[] memory tokenIds) private{
+    function _depositBatchInternal(
+        address depositToken,
+        address depositor,
+        address[] memory receivers,
+        uint256[] memory tokenIds
+    ) private {
         IChildERC721 childToken = IChildERC721(sourceTokenToDestinationToken[depositToken]);
 
         require(address(childToken) != address(0), "ChildERC721Predicate: UNMAPPED_TOKEN");

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -82,11 +82,11 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
         require(msg.sender == address(gateway), "ChildERC721Predicate: ONLY_GATEWAY");
         require(sender == rootERC721Predicate, "ChildERC721Predicate: ONLY_ROOT_PREDICATE");
 
-        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+        if (bytes32(data[:32]) == DEPOSIT_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _beforeTokenDeposit();
             _deposit(data[32:]);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG || bytes32(data[:32])== WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
             _depositBatch(data);
             _afterTokenDeposit();

--- a/contracts/blade/ChildERC721Predicate.sol
+++ b/contracts/blade/ChildERC721Predicate.sol
@@ -111,7 +111,7 @@ contract ChildERC721Predicate is IChildERC721Predicate, Predicate, Initializable
             _beforeTokenDeposit();
             _withdrawRollback(data[32:]);
             _afterTokenDeposit();
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG){
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _beforeTokenDeposit();
             _withdrawBatchRollback(data);
             _afterTokenDeposit();

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -70,12 +70,11 @@ contract Gateway is ValidatorSetStorage, IGateway {
         BridgeMessage[] calldata batchMessages,
         SignedBridgeMessageBatch calldata signedBridgeBatch
     ) external {
-        if (signedBridgeBatch.isRollback){
-        _verifyRollbackBatch(batchMessages);
-        } else{
+        if (signedBridgeBatch.isRollback) {
+            _verifyRollbackBatch(batchMessages);
+        } else {
             _verifyBatch(batchMessages);
         }
-
 
         bytes memory hash = abi.encode(
             keccak256(
@@ -146,13 +145,13 @@ contract Gateway is ValidatorSetStorage, IGateway {
         }
     }
 
-    function _verifyRollbackBatch(BridgeMessage[] calldata batch) private view{
+    function _verifyRollbackBatch(BridgeMessage[] calldata batch) private view {
         require(batch.length > 0, "EMPTY_BATCH");
 
         uint256 sourceChainId = block.chainid;
         uint256 destinationChainId = batch[0].destinationChainId;
 
-        for (uint256 i = 0; i < batch.length; ){
+        for (uint256 i = 0; i < batch.length; ) {
             BridgeMessage memory message = batch[i];
             require(message.sourceChainId == sourceChainId, "INVALID_SOURCE_CHAIN_ID");
             require(message.destinationChainId == destinationChainId, "INVALID_DESTINATION_CHAIN_ID");
@@ -161,7 +160,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
             }
         }
     }
-
 
     function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -18,7 +18,8 @@ contract Gateway is ValidatorSetStorage, IGateway {
         bool indexed status,
         uint256 sourceChainID,
         uint256 destinationChainID,
-        bytes message
+        bytes message,
+        bool isRollback
     );
 
     event BridgeMsg(
@@ -81,7 +82,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         uint256 length = batchMessages.length;
         for (uint256 i = 0; i < length; ) {
-            _executeBridgeMessage(batchMessages[i]);
+            _executeBridgeMessage(batchMessages[i], signedBridgeBatch.isRollback);
 
             unchecked {
                 ++i;
@@ -109,32 +110,67 @@ contract Gateway is ValidatorSetStorage, IGateway {
         }
     }
 
-    function _executeBridgeMessage(BridgeMessage calldata message) private {
+    function _executeBridgeMessage(BridgeMessage calldata message, bool isRollback) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
         // Skip transaction if client has added flag, or receiver has no code
         if (message.receiver.code.length == 0) {
-            emit BridgeMessageResult(message.id, false, message.sourceChainId, message.destinationChainId, "");
+            emit BridgeMessageResult(
+                message.id,
+                false,
+                message.sourceChainId,
+                message.destinationChainId,
+                "",
+                isRollback
+            );
             return;
         }
 
         processedEvents[message.id] = true;
+        if (!isRollback) {
+            // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
+            (bool success, bytes memory returnData) = message.receiver.call(
+                abi.encodeWithSignature(
+                    "onStateReceive(uint256,address,bytes)",
+                    message.id,
+                    message.sender,
+                    message.payload
+                )
+            );
+            // if bridge message fails, revert
+            if (!success) revert("Gateway: BATCH_ROLLBACK");
 
-        // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
-        (bool success, bytes memory returnData) = message.receiver.call(
-            abi.encodeWithSignature(
-                "onStateReceive(uint256,address,bytes)",
+            // emit a ResultEvent indicating whether invocation of bridge message was successful
+            // slither-disable-next-line reentrancy-events
+            emit BridgeMessageResult(
                 message.id,
-                message.sender,
-                message.payload
-            )
-        );
+                success,
+                message.sourceChainId,
+                message.destinationChainId,
+                returnData,
+                isRollback
+            );
+        } else {
+            // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
+            (bool success, bytes memory returnData) = message.receiver.call(
+                abi.encodeWithSignature(
+                    "onStateRollback(uint256,address,bytes)",
+                    message.id,
+                    message.sender,
+                    message.payload
+                )
+            );
 
-        // if bridge message fails, revert flag
-        if (!success) revert("Gateway: BATCH_ROLLBACK");
-
-        // emit a ResultEvent indicating whether invocation of bridge message was successful or not
-        // slither-disable-next-line reentrancy-events
-        emit BridgeMessageResult(message.id, success, message.sourceChainId, message.destinationChainId, returnData);
+            // emit a ResultEvent indicating whether invocation of bridge rollback message was successful or not
+            // slither-disable-next-line reentrancy-events
+            emit BridgeMessageResult(
+                message.id,
+                success,
+                message.sourceChainId,
+                message.destinationChainId,
+                returnData,
+                isRollback
+            );
+        }
     }
 
     // Function to calculate Merkle Root from an array of BridgeMessages

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -133,7 +133,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
     function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
         // Skip transaction if client has added flag, or receiver has no code
-        // Skip transaction if client has added flag, or receiver has no code
         require(message.receiver.code.length != 0, "receiver has no code");
 
         processedEvents[message.id] = true;

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -31,6 +31,14 @@ contract Gateway is ValidatorSetStorage, IGateway {
         bytes data
     );
 
+    event BridgeBatchResult(
+        uint256 startId,
+        uint256 endId,
+        uint256 sourceChainId,
+        uint256 destinationChainId,
+        bool isRollback
+    );
+
     /**
      *
      * @notice Generates sync state event based on receiver and data.
@@ -92,6 +100,14 @@ contract Gateway is ValidatorSetStorage, IGateway {
                 ++i;
             }
         }
+
+        emit BridgeBatchResult(
+            signedBridgeBatch.startId,
+            signedBridgeBatch.endId,
+            signedBridgeBatch.sourceChainId,
+            signedBridgeBatch.destinationChainId,
+            signedBridgeBatch.isRollback
+        );
     }
 
     /**
@@ -117,10 +133,8 @@ contract Gateway is ValidatorSetStorage, IGateway {
     function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
         // Skip transaction if client has added flag, or receiver has no code
-        if (message.receiver.code.length == 0) {
-            emit BridgeMessageResult(message.id, false, message.sourceChainId, message.destinationChainId, "", false);
-            return;
-        }
+        // Skip transaction if client has added flag, or receiver has no code
+        require(message.receiver.code.length != 0, "receiver has no code");
 
         processedEvents[message.id] = true;
 
@@ -134,7 +148,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
             )
         );
         // if bridge message fails, revert
-        if (!success) revert("Gateway: BATCH_ROLLBACK");
+        require(success, "Gateway: BATCH_ROLLBACK");
 
         // emit a ResultEvent indicating whether invocation of bridge message was successful
         // slither-disable-next-line reentrancy-events
@@ -150,10 +164,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
     function _executeRollbackBridgeMessage(BridgeMessage calldata message) private {
         // Skip transaction if client has added flag, or receiver has no code
-        if (message.receiver.code.length == 0) {
-            emit BridgeMessageResult(message.id, false, message.sourceChainId, message.destinationChainId, "", true);
-            return;
-        }
+        require(message.receiver.code.length != 0, "receiver has no code");
 
         // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
         (bool success, bytes memory returnData) = message.receiver.call(

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -70,7 +70,12 @@ contract Gateway is ValidatorSetStorage, IGateway {
         BridgeMessage[] calldata batchMessages,
         SignedBridgeMessageBatch calldata signedBridgeBatch
     ) external {
-        _verifyBatch(batchMessages);
+        if (signedBridgeBatch.isRollback){
+        _verifyRollbackBatch(batchMessages);
+        } else{
+            _verifyBatch(batchMessages);
+        }
+
 
         bytes memory hash = abi.encode(
             keccak256(
@@ -141,6 +146,23 @@ contract Gateway is ValidatorSetStorage, IGateway {
         }
     }
 
+    function _verifyRollbackBatch(BridgeMessage[] calldata batch) private view{
+        require(batch.length > 0, "EMPTY_BATCH");
+
+        uint256 sourceChainId = block.chainid;
+        uint256 destinationChainId = batch[0].destinationChainId;
+
+        for (uint256 i = 0; i < batch.length; ){
+            BridgeMessage memory message = batch[i];
+            require(message.sourceChainId == sourceChainId, "INVALID_SOURCE_CHAIN_ID");
+            require(message.destinationChainId == destinationChainId, "INVALID_DESTINATION_CHAIN_ID");
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+
     function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
         // revert transaction if client has added flag, or receiver has no code
@@ -170,8 +192,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
             !processedEventsRollback[message.id],
             "DestinationGateway: ROLLBACK_BRIDGE_MESSAGE_IS_ALREADY_PROCESSED"
         );
-        // revert transaction if client has added flag, or receiver has no code
-        require(message.receiver.code.length != 0, "receiver has no code");
 
         processedEventsRollback[message.id] = true;
 

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -18,8 +18,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
         bool indexed status,
         uint256 sourceChainID,
         uint256 destinationChainID,
-        bytes message,
-        bool isRollback
+        bytes message
     );
 
     event BridgeMsg(
@@ -167,8 +166,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
             success,
             message.sourceChainId,
             message.destinationChainId,
-            returnData,
-            false
+            returnData
         );
     }
 
@@ -193,8 +191,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
             success,
             message.sourceChainId,
             message.destinationChainId,
-            returnData,
-            true
+            returnData
         );
     }
 

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -82,7 +82,11 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         uint256 length = batchMessages.length;
         for (uint256 i = 0; i < length; ) {
-            _executeBridgeMessage(batchMessages[i], signedBridgeBatch.isRollback);
+            if (!signedBridgeBatch.isRollback) {
+                _executeBridgeMessage(batchMessages[i]);
+            } else {
+                _executeRollbackBridgeMessage(batchMessages[i]);
+            }
 
             unchecked {
                 ++i;
@@ -110,67 +114,67 @@ contract Gateway is ValidatorSetStorage, IGateway {
         }
     }
 
-    function _executeBridgeMessage(BridgeMessage calldata message, bool isRollback) private {
+    function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
         // Skip transaction if client has added flag, or receiver has no code
         if (message.receiver.code.length == 0) {
-            emit BridgeMessageResult(
-                message.id,
-                false,
-                message.sourceChainId,
-                message.destinationChainId,
-                "",
-                isRollback
-            );
+            emit BridgeMessageResult(message.id, false, message.sourceChainId, message.destinationChainId, "", false);
             return;
         }
 
         processedEvents[message.id] = true;
-        if (!isRollback) {
-            // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
-            (bool success, bytes memory returnData) = message.receiver.call(
-                abi.encodeWithSignature(
-                    "onStateReceive(uint256,address,bytes)",
-                    message.id,
-                    message.sender,
-                    message.payload
-                )
-            );
-            // if bridge message fails, revert
-            if (!success) revert("Gateway: BATCH_ROLLBACK");
 
-            // emit a ResultEvent indicating whether invocation of bridge message was successful
-            // slither-disable-next-line reentrancy-events
-            emit BridgeMessageResult(
+        // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
+        (bool success, bytes memory returnData) = message.receiver.call(
+            abi.encodeWithSignature(
+                "onStateReceive(uint256,address,bytes)",
                 message.id,
-                success,
-                message.sourceChainId,
-                message.destinationChainId,
-                returnData,
-                isRollback
-            );
-        } else {
-            // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
-            (bool success, bytes memory returnData) = message.receiver.call(
-                abi.encodeWithSignature(
-                    "onStateRollback(uint256,address,bytes)",
-                    message.id,
-                    message.sender,
-                    message.payload
-                )
-            );
+                message.sender,
+                message.payload
+            )
+        );
+        // if bridge message fails, revert
+        if (!success) revert("Gateway: BATCH_ROLLBACK");
 
-            // emit a ResultEvent indicating whether invocation of bridge rollback message was successful or not
-            // slither-disable-next-line reentrancy-events
-            emit BridgeMessageResult(
-                message.id,
-                success,
-                message.sourceChainId,
-                message.destinationChainId,
-                returnData,
-                isRollback
-            );
+        // emit a ResultEvent indicating whether invocation of bridge message was successful
+        // slither-disable-next-line reentrancy-events
+        emit BridgeMessageResult(
+            message.id,
+            success,
+            message.sourceChainId,
+            message.destinationChainId,
+            returnData,
+            false
+        );
+    }
+
+    function _executeRollbackBridgeMessage(BridgeMessage calldata message) private {
+        // Skip transaction if client has added flag, or receiver has no code
+        if (message.receiver.code.length == 0) {
+            emit BridgeMessageResult(message.id, false, message.sourceChainId, message.destinationChainId, "", true);
+            return;
         }
+
+        // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
+        (bool success, bytes memory returnData) = message.receiver.call(
+            abi.encodeWithSignature(
+                "onStateRollback(uint256,address,bytes)",
+                message.id,
+                message.sender,
+                message.payload
+            )
+        );
+
+        // emit a ResultEvent indicating whether invocation of bridge rollback message was successful or not
+        // slither-disable-next-line reentrancy-events
+        emit BridgeMessageResult(
+            message.id,
+            success,
+            message.sourceChainId,
+            message.destinationChainId,
+            returnData,
+            true
+        );
     }
 
     // Function to calculate Merkle Root from an array of BridgeMessages

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -109,6 +109,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
             }
         }
 
+        // slither-disable-next-line reentrancy-events
         emit BridgeBatchResult(
             signedBridgeBatch.startId,
             signedBridgeBatch.endId,

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -92,10 +92,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signedBridgeBatch.signature, signedBridgeBatch.bitmap);
 
-        if (block.number > signedBridgeBatch.threshold && !signedBridgeBatch.isRollback) {
-            revert("block number is bigger than threshold");
-        }
-
         uint256 length = batchMessages.length;
         if (!signedBridgeBatch.isRollback) {
             for (uint256 i = 0; i < length; ) {

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -88,7 +88,9 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signedBridgeBatch.signature, signedBridgeBatch.bitmap);
 
-        require(block.number < signedBridgeBatch.threshold, "block number is bigger than threshold");
+        if (block.number > signedBridgeBatch.threshold && !signedBridgeBatch.isRollback) {
+            revert("block number is bigger than threshold");
+        }
 
         uint256 length = batchMessages.length;
         if (!signedBridgeBatch.isRollback) {

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -89,15 +89,21 @@ contract Gateway is ValidatorSetStorage, IGateway {
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signedBridgeBatch.signature, signedBridgeBatch.bitmap);
 
         uint256 length = batchMessages.length;
-        for (uint256 i = 0; i < length; ) {
-            if (!signedBridgeBatch.isRollback) {
+        if (!signedBridgeBatch.isRollback) {
+            for (uint256 i = 0; i < length; ) {
                 _executeBridgeMessage(batchMessages[i]);
-            } else {
-                _executeRollbackBridgeMessage(batchMessages[i]);
-            }
 
-            unchecked {
-                ++i;
+                unchecked {
+                    ++i;
+                }
+            }
+        } else {
+            for (uint256 i = 0; i < length; ) {
+                _executeRollbackBridgeMessage(batchMessages[i]);
+
+                unchecked {
+                    ++i;
+                }
             }
         }
 

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -130,7 +130,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
         );
 
         // if bridge message fails, revert flag
-        if (!success) processedEvents[message.id] = false;
+        if (!success) revert("Gateway: BATCH_ROLLBACK");
 
         // emit a ResultEvent indicating whether invocation of bridge message was successful or not
         // slither-disable-next-line reentrancy-events

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -88,6 +88,8 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signedBridgeBatch.signature, signedBridgeBatch.bitmap);
 
+        require(block.number < signedBridgeBatch.threshold, "block number is bigger than threshold");
+
         uint256 length = batchMessages.length;
         if (!signedBridgeBatch.isRollback) {
             for (uint256 i = 0; i < length; ) {

--- a/contracts/blade/Gateway.sol
+++ b/contracts/blade/Gateway.sol
@@ -12,6 +12,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
     /// @custom:security write-protection="onlySystemCall()"
     // slither-disable-next-line protected-vars
     mapping(uint256 => bool) public processedEvents;
+    mapping(uint256 => bool) public processedEventsRollback;
 
     event BridgeMessageResult(
         uint256 indexed counter,
@@ -142,7 +143,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
     function _executeBridgeMessage(BridgeMessage calldata message) private {
         require(!processedEvents[message.id], "DestinationGateway: BRIDGE_MESSAGE_IS_ALREADY_PROCESSED");
-        // Skip transaction if client has added flag, or receiver has no code
+        // revert transaction if client has added flag, or receiver has no code
         require(message.receiver.code.length != 0, "receiver has no code");
 
         processedEvents[message.id] = true;
@@ -161,18 +162,18 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         // emit a ResultEvent indicating whether invocation of bridge message was successful
         // slither-disable-next-line reentrancy-events
-        emit BridgeMessageResult(
-            message.id,
-            success,
-            message.sourceChainId,
-            message.destinationChainId,
-            returnData
-        );
+        emit BridgeMessageResult(message.id, success, message.sourceChainId, message.destinationChainId, returnData);
     }
 
     function _executeRollbackBridgeMessage(BridgeMessage calldata message) private {
-        // Skip transaction if client has added flag, or receiver has no code
+        require(
+            !processedEventsRollback[message.id],
+            "DestinationGateway: ROLLBACK_BRIDGE_MESSAGE_IS_ALREADY_PROCESSED"
+        );
+        // revert transaction if client has added flag, or receiver has no code
         require(message.receiver.code.length != 0, "receiver has no code");
+
+        processedEventsRollback[message.id] = true;
 
         // slither-disable-next-line calls-loop,low-level-calls,reentrancy-no-eth
         (bool success, bytes memory returnData) = message.receiver.call(
@@ -186,13 +187,7 @@ contract Gateway is ValidatorSetStorage, IGateway {
 
         // emit a ResultEvent indicating whether invocation of bridge rollback message was successful or not
         // slither-disable-next-line reentrancy-events
-        emit BridgeMessageResult(
-            message.id,
-            success,
-            message.sourceChainId,
-            message.destinationChainId,
-            returnData
-        );
+        emit BridgeMessageResult(message.id, success, message.sourceChainId, message.destinationChainId, returnData);
     }
 
     // Function to calculate Merkle Root from an array of BridgeMessages

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -52,6 +52,26 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
     }
 
     /**
+     * @inheritdoc IStateReceiver
+     * @notice Function to be used for token withdrawals for rollback
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "RootERC1155Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
+
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+            _withdraw(data[32:]);
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
+            _withdrawBatch(data);
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
+            _unMapToken(data[32:]);
+        } else {
+            revert("RootERC1155Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
      * @inheritdoc IRootERC1155Predicate
      */
     function deposit(IERC1155MetadataURI rootToken, uint256 tokenId, uint256 amount) external {
@@ -169,21 +189,23 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
     }
 
     function _withdraw(bytes calldata data) private {
-        (address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256, uint256)
-        );
+        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) = abi
+            .decode(data, (bytes32, address, address, address, uint256, uint256));
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
-        IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
+        if (sig == WITHDRAW_SIG) {
+            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
+        } else {
+            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), withdrawer, tokenId, amount, "");
+        }
         // slither-disable-next-line reentrancy-events
         emit ERC1155Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId, amount);
     }
 
     function _withdrawBatch(bytes calldata data) private {
         (
-            ,
+            bytes32 sig,
             address rootToken,
             address withdrawer,
             address[] memory receivers,
@@ -192,10 +214,25 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i], amounts[i], "");
-            unchecked {
-                ++i;
+        if (sig == WITHDRAW_SIG) {
+            for (uint256 i = 0; i < tokenIds.length; ) {
+                IERC1155MetadataURI(rootToken).safeTransferFrom(
+                    address(this),
+                    receivers[i],
+                    tokenIds[i],
+                    amounts[i],
+                    ""
+                );
+                unchecked {
+                    ++i;
+                }
+            }
+        } else {
+            for (uint256 i = 0; i < tokenIds.length; ) {
+                IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), withdrawer, tokenIds[i], amounts[i], "");
+                unchecked {
+                    ++i;
+                }
             }
         }
         // slither-disable-next-line reentrancy-events

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -43,7 +43,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
-            _withdrawBatch(data[32:]);
+            _withdrawBatch(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -63,7 +63,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatch(data[32:]);
+            _withdrawBatch(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -218,12 +218,13 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
 
     function _withdrawBatch(bytes calldata data) private {
         (
+            ,
             address rootToken,
             address withdrawer,
             address[] memory receivers,
             uint256[] memory tokenIds,
             uint256[] memory amounts
-        ) = abi.decode(data, (address, address, address[], uint256[], uint256[]));
+        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
         address childToken = _getChildTokenWithdraw(rootToken);
 
         for (uint256 i = 0; i < tokenIds.length; ) {

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -116,7 +116,10 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC1155Predicate: INVALID_TOKEN");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0),"RootERC1155Predicate: TOKEN_IS_ALREADY_UNMAPPED");
+        require(
+            sourceTokenToDestinationToken[address(rootToken)] != address(0),
+            "RootERC1155Predicate: TOKEN_IS_ALREADY_UNMAPPED"
+        );
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -41,7 +41,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(sender == childERC1155Predicate, "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
-            _withdraw(data[32:]);
+            _withdraw(data);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _withdrawBatch(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
@@ -58,7 +58,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
      */
     function onStateRollback(uint256 /* id */, address sender, bytes calldata data) external {
         require(msg.sender == address(gateway), "RootERC1155Predicate: ONLY_GATEWAY");
-        require(sender == address(this), "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
+        require(sender == address(this), "RootERC1155Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data[32:]);

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -40,12 +40,10 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(msg.sender == address(gateway), "RootERC1155Predicate: ONLY_GATEWAY");
         require(sender == childERC1155Predicate, "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
 
-        if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _withdrawBatch(data);
-        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
-            _unMapToken(data[32:]);
         } else {
             revert("RootERC1155Predicate: INVALID_SIGNATURE");
         }
@@ -61,9 +59,9 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(sender == address(this), "RootERC1155Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdrawRollback(data[32:]);
+            _depositRollback(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatchRollback(data);
+            _depositBatchRollback(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -188,32 +186,50 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         _afterTokenDeposit();
     }
 
+    function _depositRollback(bytes calldata data) private{
+        (address rootToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
+
+        _withdrawInternal(rootToken, depositor, depositor, tokenId, amount);
+    }
+
     function _withdraw(bytes calldata data) private {
         (address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
         );
 
-        address childToken = _getChildTokenWithdraw(rootToken);
+        _withdrawInternal(rootToken, withdrawer, receiver, tokenId, amount);
+    }
 
-        _withdrawInternal(rootToken, receiver, tokenId, amount);
+    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) private{
+        address childToken = sourceTokenToDestinationToken[rootToken];
+        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
+
+        IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
         // slither-disable-next-line reentrancy-events
         emit ERC1155Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId, amount);
     }
 
-    function _withdrawRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256, uint256)
-        );
+    function _depositBatchRollback(bytes calldata data) private{
+        (
+            ,
+            address rootToken,
+            address depositor,
+            ,
+            uint256[] memory tokenIds,
+            uint256[] memory amounts
+        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
 
-        _getChildTokenWithdraw(rootToken);
+        address[] memory depositors = new address[](tokenIds.length);
+        for (uint256 i = 0; i<tokenIds.length; i++){
+            depositors[i] = depositor;
+        }
 
-        _withdrawInternal(rootToken, depositor, tokenId, amount);
-    }
-
-    function _withdrawInternal(address rootToken, address receiver, uint256 tokenId, uint256 amount) private {
-        IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
+        _withdrawBatchInternal(rootToken, depositor, depositors, tokenIds, amounts);
+        
     }
 
     function _withdrawBatch(bytes calldata data) private {
@@ -225,43 +241,29 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
             uint256[] memory tokenIds,
             uint256[] memory amounts
         ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
-        address childToken = _getChildTokenWithdraw(rootToken);
 
+        _withdrawBatchInternal(rootToken, withdrawer, receivers, tokenIds, amounts);
+    }
+
+    function _withdrawBatchInternal(address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds, uint256[] memory amounts) private{
+        address childToken = sourceTokenToDestinationToken[rootToken];
+        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
         for (uint256 i = 0; i < tokenIds.length; ) {
-            _withdrawInternal(rootToken, receivers[i], tokenIds[i], amounts[i]);
+            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i], amounts[i], "");
             unchecked {
                 ++i;
             }
         }
-
         // slither-disable-next-line reentrancy-events
         emit ERC1155WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds, amounts);
     }
 
-    function _withdrawBatchRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
-            data,
-            (address, address, address[], uint256[], uint256[])
-        );
 
-        _getChildTokenWithdraw(rootToken);
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            _withdrawInternal(rootToken, depositor, tokenIds[i], amounts[i]);
-            unchecked {
-                ++i;
-            }
-        }
-    }
 
     function _getChildToken(IERC1155MetadataURI rootToken) private returns (address childToken) {
         childToken = sourceTokenToDestinationToken[address(rootToken)];
         if (childToken == address(0)) childToken = mapToken(IERC1155MetadataURI(rootToken));
         assert(childToken != address(0)); // invariant because we map the token if mapping does not exist
-    }
-
-    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
-        childToken = sourceTokenToDestinationToken[address(rootToken)];
-        assert(childToken != address(0));
     }
 
     /**

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -40,11 +40,14 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(msg.sender == address(gateway), "RootERC1155Predicate: ONLY_GATEWAY");
         require(sender == childERC1155Predicate, "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
 
-        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _withdrawBatch(data);
-        } else {
+        }else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+            _unMapToken(data[32:]);
+        } 
+        else {
             revert("RootERC1155Predicate: INVALID_SIGNATURE");
         }
     }
@@ -109,6 +112,19 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         gateway.sendBridgeMsg(childPredicate, abi.encode(MAP_TOKEN_SIG, rootToken, uri), destinationChainId);
         // slither-disable-next-line reentrancy-events
         emit TokenMapped(address(rootToken), childToken);
+    }
+
+    function _unMapToken(bytes calldata data) private{
+        (address rootToken, , , ) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+        require(address(rootToken) != address(0), "RootERC1155Predicate: TOKEN IS ALREADY UNMAPPED");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+
+        sourceTokenToDestinationToken[rootToken] = address(0);
+
+        emit TokenUnMapped(rootToken);
     }
 
     function _deposit(IERC1155MetadataURI rootToken, address receiver, uint256 tokenId, uint256 amount) private {

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -44,10 +44,9 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
             _withdrawBatch(data);
-        }else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
-        } 
-        else {
+        } else {
             revert("RootERC1155Predicate: INVALID_SIGNATURE");
         }
     }
@@ -114,11 +113,8 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         emit TokenMapped(address(rootToken), childToken);
     }
 
-    function _unMapToken(bytes calldata data) private{
-        (address rootToken, , , ) = abi.decode(
-            data,
-            (address, address, address, uint256)
-        );
+    function _unMapToken(bytes calldata data) private {
+        (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC1155Predicate: TOKEN IS ALREADY UNMAPPED");
         require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
 

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -186,7 +186,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         _afterTokenDeposit();
     }
 
-    function _depositRollback(bytes calldata data) private{
+    function _depositRollback(bytes calldata data) private {
         (address rootToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
@@ -204,7 +204,13 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         _withdrawInternal(rootToken, withdrawer, receiver, tokenId, amount);
     }
 
-    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) private{
+    function _withdrawInternal(
+        address rootToken,
+        address withdrawer,
+        address receiver,
+        uint256 tokenId,
+        uint256 amount
+    ) private {
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
@@ -213,23 +219,18 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         emit ERC1155Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId, amount);
     }
 
-    function _depositBatchRollback(bytes calldata data) private{
-        (
-            ,
-            address rootToken,
-            address depositor,
-            ,
-            uint256[] memory tokenIds,
-            uint256[] memory amounts
-        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
+    function _depositBatchRollback(bytes calldata data) private {
+        (, address rootToken, address depositor, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
+            data,
+            (bytes32, address, address, address[], uint256[], uint256[])
+        );
 
         address[] memory depositors = new address[](tokenIds.length);
-        for (uint256 i = 0; i<tokenIds.length; i++){
+        for (uint256 i = 0; i < tokenIds.length; i++) {
             depositors[i] = depositor;
         }
 
         _withdrawBatchInternal(rootToken, depositor, depositors, tokenIds, amounts);
-        
     }
 
     function _withdrawBatch(bytes calldata data) private {
@@ -245,7 +246,13 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         _withdrawBatchInternal(rootToken, withdrawer, receivers, tokenIds, amounts);
     }
 
-    function _withdrawBatchInternal(address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds, uint256[] memory amounts) private{
+    function _withdrawBatchInternal(
+        address rootToken,
+        address withdrawer,
+        address[] memory receivers,
+        uint256[] memory tokenIds,
+        uint256[] memory amounts
+    ) private {
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
         for (uint256 i = 0; i < tokenIds.length; ) {
@@ -257,8 +264,6 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         // slither-disable-next-line reentrancy-events
         emit ERC1155WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds, amounts);
     }
-
-
 
     function _getChildToken(IERC1155MetadataURI rootToken) private returns (address childToken) {
         childToken = sourceTokenToDestinationToken[address(rootToken)];

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -115,8 +115,8 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
 
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
-        require(address(rootToken) != address(0), "RootERC1155Predicate: TOKEN IS ALREADY UNMAPPED");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+        require(address(rootToken) != address(0), "RootERC1155Predicate: INVALID_TOKEN");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0),"RootERC1155Predicate: TOKEN_IS_ALREADY_UNMAPPED");
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -187,12 +187,12 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
     }
 
     function _depositRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
+        (address rootToken, address sender, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256, uint256)
         );
 
-        _withdrawInternal(rootToken, depositor, depositor, tokenId, amount);
+        _withdrawInternal(rootToken, receiver, sender, tokenId, amount);
     }
 
     function _withdraw(bytes calldata data) private {

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -41,9 +41,9 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(sender == childERC1155Predicate, "RootERC1155Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == WITHDRAW_SIG) {
-            _withdraw(data);
+            _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
-            _withdrawBatch(data);
+            _withdrawBatch(data[32:]);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -63,7 +63,7 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatch(data);
+            _withdrawBatch(data[32:]);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -189,60 +189,78 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
     }
 
     function _withdraw(bytes calldata data) private {
-        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) = abi
-            .decode(data, (bytes32, address, address, address, uint256, uint256));
-        address childToken = sourceTokenToDestinationToken[rootToken];
-        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
+        (address rootToken, address withdrawer, address receiver, uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
 
-        if (sig == WITHDRAW_SIG) {
-            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
-        } else {
-            IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), withdrawer, tokenId, amount, "");
-        }
+        address childToken = _getChildTokenWithdraw(rootToken);
+
+        _withdrawInternal(rootToken, receiver, tokenId, amount);
         // slither-disable-next-line reentrancy-events
         emit ERC1155Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId, amount);
     }
 
+    function _withdrawRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256 tokenId, uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256, uint256)
+        );
+
+        _getChildTokenWithdraw(rootToken);
+
+        _withdrawInternal(rootToken, depositor, tokenId, amount);
+    }
+
+    function _withdrawInternal(address rootToken, address receiver, uint256 tokenId, uint256 amount) private {
+        IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), receiver, tokenId, amount, "");
+    }
+
     function _withdrawBatch(bytes calldata data) private {
         (
-            bytes32 sig,
             address rootToken,
             address withdrawer,
             address[] memory receivers,
             uint256[] memory tokenIds,
             uint256[] memory amounts
-        ) = abi.decode(data, (bytes32, address, address, address[], uint256[], uint256[]));
-        address childToken = sourceTokenToDestinationToken[rootToken];
-        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
-        if (sig == WITHDRAW_SIG) {
-            for (uint256 i = 0; i < tokenIds.length; ) {
-                IERC1155MetadataURI(rootToken).safeTransferFrom(
-                    address(this),
-                    receivers[i],
-                    tokenIds[i],
-                    amounts[i],
-                    ""
-                );
-                unchecked {
-                    ++i;
-                }
-            }
-        } else {
-            for (uint256 i = 0; i < tokenIds.length; ) {
-                IERC1155MetadataURI(rootToken).safeTransferFrom(address(this), withdrawer, tokenIds[i], amounts[i], "");
-                unchecked {
-                    ++i;
-                }
+        ) = abi.decode(data, (address, address, address[], uint256[], uint256[]));
+        address childToken = _getChildTokenWithdraw(rootToken);
+
+        for (uint256 i = 0; i < tokenIds.length; ) {
+            _withdrawInternal(rootToken, receivers[i], tokenIds[i], amounts[i]);
+            unchecked {
+                ++i;
             }
         }
+
         // slither-disable-next-line reentrancy-events
         emit ERC1155WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds, amounts);
+    }
+
+    function _withdrawBatchRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256[] memory tokenIds, uint256[] memory amounts) = abi.decode(
+            data,
+            (address, address, address[], uint256[], uint256[])
+        );
+
+        _getChildTokenWithdraw(rootToken);
+        for (uint256 i = 0; i < tokenIds.length; ) {
+            _withdrawInternal(rootToken, depositor, tokenIds[i], amounts[i]);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     function _getChildToken(IERC1155MetadataURI rootToken) private returns (address childToken) {
         childToken = sourceTokenToDestinationToken[address(rootToken)];
         if (childToken == address(0)) childToken = mapToken(IERC1155MetadataURI(rootToken));
         assert(childToken != address(0)); // invariant because we map the token if mapping does not exist
+    }
+
+    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
+        childToken = sourceTokenToDestinationToken[address(rootToken)];
+        assert(childToken != address(0));
     }
 
     /**

--- a/contracts/bridge/RootERC1155Predicate.sol
+++ b/contracts/bridge/RootERC1155Predicate.sol
@@ -61,9 +61,9 @@ contract RootERC1155Predicate is Predicate, Initializable, ERC1155Holder, IRootE
         require(sender == address(this), "RootERC1155Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdraw(data[32:]);
+            _withdrawRollback(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatch(data);
+            _withdrawBatchRollback(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -65,12 +65,11 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == DEPOSIT_SIG){
+        } else if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
-        }
-        else {
+        } else {
             revert("RootERC20Predicate: INVALID_SIGNATURE");
         }
     }
@@ -94,7 +93,10 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
      */
     function mapToken(IERC20Metadata rootToken) public returns (address) {
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
-        require(sourceTokenToDestinationToken[address(rootToken)] == address(0), "RootERC20Predicate: TOKEN IS ALREADY UNMAPPED");
+        require(
+            sourceTokenToDestinationToken[address(rootToken)] == address(0),
+            "RootERC20Predicate: TOKEN IS ALREADY UNMAPPED"
+        );
 
         address childPredicate = childERC20Predicate;
 
@@ -117,11 +119,8 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         return childToken;
     }
 
-    function _unMapToken(bytes calldata data) private{
-        (address rootToken, , , ) = abi.decode(
-            data,
-            (address, address, address, uint256)
-        );
+    function _unMapToken(bytes calldata data) private {
+        (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
         require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
 

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -121,8 +121,8 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
 
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
-        require(address(rootToken) != address(0), "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+        require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0), "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED");
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -70,7 +70,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         }
     }
 
-    /**
+        /**
      * @inheritdoc IStateReceiver
      * @notice Function to be used for token withdrawals for rollback
      * @dev Can be extended to include other signatures for more functionality
@@ -80,7 +80,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         require(sender == address(this), "RootERC20Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdrawRollback(data[32:]);
+            _depositRollback(data[32:]);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -130,19 +130,6 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         return childToken;
     }
 
-    function _unMapToken(bytes calldata data) private {
-        (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
-        require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
-        require(
-            sourceTokenToDestinationToken[address(rootToken)] != address(0),
-            "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
-        );
-
-        sourceTokenToDestinationToken[rootToken] = address(0);
-
-        emit TokenUnMapped(rootToken);
-    }
-
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {
         _beforeTokenDeposit();
         address childToken = sourceTokenToDestinationToken[address(rootToken)];
@@ -166,38 +153,44 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         _afterTokenDeposit();
     }
 
+    function _depositRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _withdrawInternal(rootToken, depositor, depositor, amount);
+    }
+
     function _withdraw(bytes calldata data) private {
         (address rootToken, address withdrawer, address receiver, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        address childToken = _getChildTokenWithdraw(rootToken);
+        _withdrawInternal(rootToken, withdrawer, receiver, amount);
+    }
 
-        _wtihdrawInternal(rootToken, receiver, amount);
+    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 amount) private{
+        address childToken = sourceTokenToDestinationToken[rootToken];
+        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
+        IERC20Metadata(rootToken).safeTransfer(receiver, amount);
         // slither-disable-next-line reentrancy-events
         emit ERC20Withdraw(address(rootToken), childToken, withdrawer, receiver, amount);
-    }
+    } 
 
-    function _withdrawRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 amount) = abi.decode(
-            data,
-            (address, address, address, uint256)
+    function _unMapToken(bytes calldata data) private {
+        (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
+        require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
+        require(
+            sourceTokenToDestinationToken[address(rootToken)] != address(0),
+            "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
         );
 
-        _getChildTokenWithdraw(rootToken);
+        sourceTokenToDestinationToken[rootToken] = address(0);
 
-        _wtihdrawInternal(rootToken, depositor, amount);
-    }
-
-    function _wtihdrawInternal(address rootToken, address receiver, uint256 amount) private {
-        IERC20Metadata(rootToken).safeTransfer(receiver, amount);
-    }
-
-    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
-        childToken = sourceTokenToDestinationToken[address(rootToken)];
-        assert(childToken != address(0));
+        emit TokenUnMapped(rootToken);
     }
 
     /**

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -95,7 +95,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
         require(
             sourceTokenToDestinationToken[address(rootToken)] == address(0),
-            "RootERC20Predicate: TOKEN IS ALREADY UNMAPPED"
+            "RootERC20Predicate: ALREADY_MAPPED"
         );
 
         address childPredicate = childERC20Predicate;
@@ -121,7 +121,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
 
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
-        require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
+        require(address(rootToken) != address(0), "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED");
         require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
 
         sourceTokenToDestinationToken[rootToken] = address(0);

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -64,7 +64,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         require(sender == childERC20Predicate, "RootERC20Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
-            _withdraw(data);
+            _withdraw(data[32:]);
         } else {
             revert("RootERC20Predicate: INVALID_SIGNATURE");
         }
@@ -80,7 +80,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         require(sender == address(this), "RootERC20Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdraw(data);
+            _withdrawRollback(data[32:]);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -167,21 +167,37 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
     }
 
     function _withdraw(bytes calldata data) private {
-        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 amount) = abi.decode(
+        (address rootToken, address withdrawer, address receiver, uint256 amount) = abi.decode(
             data,
-            (bytes32, address, address, address, uint256)
+            (address, address, address, uint256)
         );
-        address childToken = sourceTokenToDestinationToken[rootToken];
-        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
-        if (sig == DEPOSIT_SIG) {
-            IERC20Metadata(rootToken).safeTransfer(receiver, amount);
-        } else {
-            IERC20Metadata(rootToken).safeTransfer(withdrawer, amount);
-        }
+        address childToken = _getChildTokenWithdraw(rootToken);
+
+        _wtihdrawInternal(rootToken, receiver, amount);
 
         // slither-disable-next-line reentrancy-events
         emit ERC20Withdraw(address(rootToken), childToken, withdrawer, receiver, amount);
+    }
+
+    function _withdrawRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256 amount) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _getChildTokenWithdraw(rootToken);
+
+        _wtihdrawInternal(rootToken, depositor, amount);
+    }
+
+    function _wtihdrawInternal(address rootToken, address receiver, uint256 amount) private {
+        IERC20Metadata(rootToken).safeTransfer(receiver, amount);
+    }
+
+    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
+        childToken = sourceTokenToDestinationToken[address(rootToken)];
+        assert(childToken != address(0));
     }
 
     /**

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -65,7 +65,12 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
-        } else {
+        } else if (bytes32(data[:32]) == DEPOSIT_SIG){
+            _withdraw(data[32:]);
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+            _unMapToken(data[32:]);
+        }
+        else {
             revert("RootERC20Predicate: INVALID_SIGNATURE");
         }
     }
@@ -89,7 +94,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
      */
     function mapToken(IERC20Metadata rootToken) public returns (address) {
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
-        require(sourceTokenToDestinationToken[address(rootToken)] == address(0), "RootERC20Predicate: ALREADY_MAPPED");
+        require(sourceTokenToDestinationToken[address(rootToken)] == address(0), "RootERC20Predicate: TOKEN IS ALREADY UNMAPPED");
 
         address childPredicate = childERC20Predicate;
 
@@ -110,6 +115,19 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         emit TokenMapped(address(rootToken), childToken);
 
         return childToken;
+    }
+
+    function _unMapToken(bytes calldata data) private{
+        (address rootToken, , , ) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+        require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+
+        sourceTokenToDestinationToken[rootToken] = address(0);
+
+        emit TokenUnMapped(rootToken);
     }
 
     function _deposit(IERC20Metadata rootToken, address receiver, uint256 amount) private {

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -64,9 +64,23 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         require(sender == childERC20Predicate, "RootERC20Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
-            _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdraw(data[32:]);
+            _withdraw(data);
+        } else {
+            revert("RootERC20Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
+     * @inheritdoc IStateReceiver
+     * @notice Function to be used for token withdrawals for rollback
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /*  id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "RootERC20Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "RootERC20Predicate: ONLY_ROOT_PREDICATE");
+
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+            _withdraw(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -153,14 +167,19 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
     }
 
     function _withdraw(bytes calldata data) private {
-        (address rootToken, address withdrawer, address receiver, uint256 amount) = abi.decode(
+        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 amount) = abi.decode(
             data,
-            (address, address, address, uint256)
+            (bytes32, address, address, address, uint256)
         );
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
-        IERC20Metadata(rootToken).safeTransfer(receiver, amount);
+        if (sig == DEPOSIT_SIG) {
+            IERC20Metadata(rootToken).safeTransfer(receiver, amount);
+        } else {
+            IERC20Metadata(rootToken).safeTransfer(withdrawer, amount);
+        }
+
         // slither-disable-next-line reentrancy-events
         emit ERC20Withdraw(address(rootToken), childToken, withdrawer, receiver, amount);
     }

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -70,7 +70,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         }
     }
 
-        /**
+    /**
      * @inheritdoc IStateReceiver
      * @notice Function to be used for token withdrawals for rollback
      * @dev Can be extended to include other signatures for more functionality
@@ -171,14 +171,14 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
         _withdrawInternal(rootToken, withdrawer, receiver, amount);
     }
 
-    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 amount) private{
+    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 amount) private {
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
         IERC20Metadata(rootToken).safeTransfer(receiver, amount);
         // slither-disable-next-line reentrancy-events
         emit ERC20Withdraw(address(rootToken), childToken, withdrawer, receiver, amount);
-    } 
+    }
 
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -154,12 +154,12 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
     }
 
     function _depositRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 amount) = abi.decode(
+        (address rootToken, address sender, address receiver, uint256 amount) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        _withdrawInternal(rootToken, depositor, depositor, amount);
+        _withdrawInternal(rootToken, receiver, sender, amount);
     }
 
     function _withdraw(bytes calldata data) private {

--- a/contracts/bridge/RootERC20Predicate.sol
+++ b/contracts/bridge/RootERC20Predicate.sol
@@ -93,10 +93,7 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
      */
     function mapToken(IERC20Metadata rootToken) public returns (address) {
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
-        require(
-            sourceTokenToDestinationToken[address(rootToken)] == address(0),
-            "RootERC20Predicate: ALREADY_MAPPED"
-        );
+        require(sourceTokenToDestinationToken[address(rootToken)] == address(0), "RootERC20Predicate: ALREADY_MAPPED");
 
         address childPredicate = childERC20Predicate;
 
@@ -122,7 +119,10 @@ contract RootERC20Predicate is Predicate, Initializable, IRootERC20Predicate {
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC20Predicate: INVALID_TOKEN");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0), "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED");
+        require(
+            sourceTokenToDestinationToken[address(rootToken)] != address(0),
+            "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
+        );
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -55,8 +55,8 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
      * @dev Can be extended to include other signatures for more functionality
      */
     function onStateRollback(uint256 /*  id */, address sender, bytes calldata data) external {
-        require(msg.sender == address(gateway), "RootERC20Predicate: ONLY_GATEWAY");
-        require(sender == address(this), "RootERC20Predicate: ONLY_ROOT_PREDICATE");
+        require(msg.sender == address(gateway), "RootERC721Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "RootERC721Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data);
@@ -65,7 +65,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
-            revert("RootERC20Predicate: INVALID_SIGNATURE");
+            revert("RootERC721Predicate: INVALID_SIGNATURE");
         }
     }
 

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -49,7 +49,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         }
     }
 
-    /**
+        /**
      * @inheritdoc IStateReceiver
      * @notice Function to be used for token withdrawals for rollback
      * @dev Can be extended to include other signatures for more functionality
@@ -59,9 +59,9 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         require(sender == address(this), "RootERC721Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdrawRollback(data[32:]);
+            _depositRollback(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatchRollback(data);
+            _depositBatchRollback(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -176,33 +176,46 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         _afterTokenDeposit();
     }
 
+    function _depositRollback(bytes calldata data) private{
+        (address rootToken, address depositor, , uint256 tokenId) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _withdrawInternal(rootToken, depositor, depositor,tokenId);
+    }
+
     function _withdraw(bytes calldata data) private {
         (address rootToken, address withdrawer, address receiver, uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        address childToken = _getChildTokenWithdraw(rootToken);
+        _withdrawInternal(rootToken, withdrawer, receiver, tokenId);
+    }
 
-        _withdrawInternal(rootToken, receiver, tokenId);
+    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 tokenId) private{
+        address childToken = sourceTokenToDestinationToken[rootToken];
+        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
+        IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
         // slither-disable-next-line reentrancy-events
         emit ERC721Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId);
     }
 
-    function _withdrawRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 tokenId) = abi.decode(
+    function _depositBatchRollback(bytes calldata data) private{
+                (, address rootToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
             data,
-            (address, address, address, uint256)
+            (bytes32, address, address, address[], uint256[])
         );
 
-        _getChildTokenWithdraw(rootToken);
+    address[] memory depositors = new address[](tokenIds.length);
 
-        _withdrawInternal(rootToken, depositor, tokenId);
+    for (uint256 i = 0; i< tokenIds.length; i++){
+        depositors[i] = depositor;
     }
 
-    function _withdrawInternal(address rootToken, address receiver, uint256 tokenId) private {
-        IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
+    _withdrawBatchInternal(rootToken, depositor, depositors, tokenIds);
     }
 
     function _withdrawBatch(bytes calldata data) private {
@@ -211,43 +224,26 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
             (bytes32, address, address, address[], uint256[])
         );
 
-        address childToken = _getChildTokenWithdraw(rootToken);
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            _withdrawInternal(rootToken, receivers[i], tokenIds[i]);
-            unchecked {
-                ++i;
-            }
-        }
-
-        // slither-disable-next-line reentrancy-events
-        emit ERC721WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds);
+        _withdrawBatchInternal(rootToken, withdrawer, receivers, tokenIds);
     }
 
-    function _withdrawBatchRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
-            data,
-            (address, address, address[], uint256[])
-        );
-
-        _getChildTokenWithdraw(rootToken);
-
+    function _withdrawBatchInternal(address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) private {
+        address childToken = sourceTokenToDestinationToken[rootToken];
+        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
         for (uint256 i = 0; i < tokenIds.length; ) {
-            _withdrawInternal(rootToken, depositor, tokenIds[i]);
+            IERC721Metadata(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i]);
             unchecked {
                 ++i;
             }
         }
+        // slither-disable-next-line reentrancy-events
+        emit ERC721WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds);
     }
 
     function _getChildToken(IERC721Metadata rootToken) private returns (address childToken) {
         childToken = sourceTokenToDestinationToken[address(rootToken)];
         if (childToken == address(0)) childToken = mapToken(IERC721Metadata(rootToken));
         assert(childToken != address(0)); // invariant because we map the token if mapping does not exist
-    }
-
-    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
-        childToken = sourceTokenToDestinationToken[address(rootToken)];
-        assert(childToken != address(0));
     }
 
     // solhint-disable no-empty-blocks

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -49,7 +49,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         }
     }
 
-        /**
+    /**
      * @inheritdoc IStateReceiver
      * @notice Function to be used for token withdrawals for rollback
      * @dev Can be extended to include other signatures for more functionality
@@ -176,13 +176,13 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         _afterTokenDeposit();
     }
 
-    function _depositRollback(bytes calldata data) private{
+    function _depositRollback(bytes calldata data) private {
         (address rootToken, address depositor, , uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        _withdrawInternal(rootToken, depositor, depositor,tokenId);
+        _withdrawInternal(rootToken, depositor, depositor, tokenId);
     }
 
     function _withdraw(bytes calldata data) private {
@@ -194,7 +194,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         _withdrawInternal(rootToken, withdrawer, receiver, tokenId);
     }
 
-    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 tokenId) private{
+    function _withdrawInternal(address rootToken, address withdrawer, address receiver, uint256 tokenId) private {
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
@@ -203,19 +203,19 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         emit ERC721Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId);
     }
 
-    function _depositBatchRollback(bytes calldata data) private{
-                (, address rootToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
+    function _depositBatchRollback(bytes calldata data) private {
+        (, address rootToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
             data,
             (bytes32, address, address, address[], uint256[])
         );
 
-    address[] memory depositors = new address[](tokenIds.length);
+        address[] memory depositors = new address[](tokenIds.length);
 
-    for (uint256 i = 0; i< tokenIds.length; i++){
-        depositors[i] = depositor;
-    }
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            depositors[i] = depositor;
+        }
 
-    _withdrawBatchInternal(rootToken, depositor, depositors, tokenIds);
+        _withdrawBatchInternal(rootToken, depositor, depositors, tokenIds);
     }
 
     function _withdrawBatch(bytes calldata data) private {
@@ -227,7 +227,12 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         _withdrawBatchInternal(rootToken, withdrawer, receivers, tokenIds);
     }
 
-    function _withdrawBatchInternal(address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) private {
+    function _withdrawBatchInternal(
+        address rootToken,
+        address withdrawer,
+        address[] memory receivers,
+        uint256[] memory tokenIds
+    ) private {
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
         for (uint256 i = 0; i < tokenIds.length; ) {

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -43,7 +43,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
-            _withdrawBatch(data[32:]);
+            _withdrawBatch(data);
         } else {
             revert("RootERC721Predicate: INVALID_SIGNATURE");
         }
@@ -61,7 +61,7 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdrawRollback(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatchRollback(data[32:]);
+            _withdrawBatchRollback(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -206,9 +206,9 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
     }
 
     function _withdrawBatch(bytes calldata data) private {
-        (address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
+        (, address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
             data,
-            (address, address, address[], uint256[])
+            (bytes32, address, address, address[], uint256[])
         );
 
         address childToken = _getChildTokenWithdraw(rootToken);

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -41,9 +41,9 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         require(sender == childERC721Predicate, "RootERC721Predicate: ONLY_CHILD_PREDICATE");
 
         if (bytes32(data[:32]) == WITHDRAW_SIG) {
-            _withdraw(data);
+            _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
-            _withdrawBatch(data);
+            _withdrawBatch(data[32:]);
         } else {
             revert("RootERC721Predicate: INVALID_SIGNATURE");
         }
@@ -59,9 +59,9 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         require(sender == address(this), "RootERC721Predicate: ONLY_ROOT_PREDICATE");
 
         if (bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdraw(data);
+            _withdrawRollback(data[32:]);
         } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
-            _withdrawBatch(data);
+            _withdrawBatchRollback(data[32:]);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
@@ -177,55 +177,77 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
     }
 
     function _withdraw(bytes calldata data) private {
-        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 tokenId) = abi.decode(
+        (address rootToken, address withdrawer, address receiver, uint256 tokenId) = abi.decode(
             data,
-            (bytes32, address, address, address, uint256)
+            (address, address, address, uint256)
         );
-        address childToken = sourceTokenToDestinationToken[rootToken];
-        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
-        if (sig == WITHDRAW_SIG) {
-            IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
-        } else {
-            IERC721Metadata(rootToken).safeTransferFrom(address(this), withdrawer, tokenId);
-        }
+        address childToken = _getChildTokenWithdraw(rootToken);
+
+        _withdrawInternal(rootToken, receiver, tokenId);
+
         // slither-disable-next-line reentrancy-events
         emit ERC721Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId);
     }
 
+    function _withdrawRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256 tokenId) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+
+        _getChildTokenWithdraw(rootToken);
+
+        _withdrawInternal(rootToken, depositor, tokenId);
+    }
+
+    function _withdrawInternal(address rootToken, address receiver, uint256 tokenId) private {
+        IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
+    }
+
     function _withdrawBatch(bytes calldata data) private {
-        (
-            bytes32 sig,
-            address rootToken,
-            address withdrawer,
-            address[] memory receivers,
-            uint256[] memory tokenIds
-        ) = abi.decode(data, (bytes32, address, address, address[], uint256[]));
-        address childToken = sourceTokenToDestinationToken[rootToken];
-        assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
-        if (sig == WITHDRAW_BATCH_SIG)
-            for (uint256 i = 0; i < tokenIds.length; ) {
-                IERC721Metadata(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i]);
-                unchecked {
-                    ++i;
-                }
-            }
-        else {
-            for (uint256 i = 0; i < tokenIds.length; ) {
-                IERC721Metadata(rootToken).safeTransferFrom(address(this), withdrawer, tokenIds[i]);
-                unchecked {
-                    ++i;
-                }
+        (address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
+            data,
+            (address, address, address[], uint256[])
+        );
+
+        address childToken = _getChildTokenWithdraw(rootToken);
+        for (uint256 i = 0; i < tokenIds.length; ) {
+            _withdrawInternal(rootToken, receivers[i], tokenIds[i]);
+            unchecked {
+                ++i;
             }
         }
+
         // slither-disable-next-line reentrancy-events
         emit ERC721WithdrawBatch(address(rootToken), childToken, withdrawer, receivers, tokenIds);
+    }
+
+    function _withdrawBatchRollback(bytes calldata data) private {
+        (address rootToken, address depositor, , uint256[] memory tokenIds) = abi.decode(
+            data,
+            (address, address, address[], uint256[])
+        );
+
+        _getChildTokenWithdraw(rootToken);
+
+        for (uint256 i = 0; i < tokenIds.length; ) {
+            _withdrawInternal(rootToken, depositor, tokenIds[i]);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     function _getChildToken(IERC721Metadata rootToken) private returns (address childToken) {
         childToken = sourceTokenToDestinationToken[address(rootToken)];
         if (childToken == address(0)) childToken = mapToken(IERC721Metadata(rootToken));
         assert(childToken != address(0)); // invariant because we map the token if mapping does not exist
+    }
+
+    function _getChildTokenWithdraw(address rootToken) private view returns (address childToken) {
+        childToken = sourceTokenToDestinationToken[address(rootToken)];
+        assert(childToken != address(0));
     }
 
     // solhint-disable no-empty-blocks

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -107,7 +107,10 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC721Predicate: INVALID_TOKEN");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0), "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED");
+        require(
+            sourceTokenToDestinationToken[address(rootToken)] != address(0),
+            "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED"
+        );
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -106,8 +106,8 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
 
     function _unMapToken(bytes calldata data) private {
         (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
-        require(address(rootToken) != address(0), "RootERC721Predicate: TOKEN IS ALREADY UNMAPPED");
-        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+        require(address(rootToken) != address(0), "RootERC721Predicate: INVALID_TOKEN");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0), "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED");
 
         sourceTokenToDestinationToken[rootToken] = address(0);
 

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -40,11 +40,13 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         require(msg.sender == address(gateway), "RootERC721Predicate: ONLY_GATEWAY");
         require(sender == childERC721Predicate, "RootERC721Predicate: ONLY_CHILD_PREDICATE");
 
-        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+        if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == DEPOSIT_SIG) {
             _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _withdrawBatch(data);
-        } else {
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+            _unMapToken(data[32:]);
+        }else{
             revert("RootERC721Predicate: INVALID_SIGNATURE");
         }
     }
@@ -100,6 +102,19 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         // slither-disable-next-line reentrancy-events
         emit TokenMapped(address(rootToken), childToken);
         return childToken;
+    }
+
+    function _unMapToken(bytes calldata data) private{
+        (address rootToken, , , ) = abi.decode(
+            data,
+            (address, address, address, uint256)
+        );
+        require(address(rootToken) != address(0), "RootERC721Predicate: TOKEN IS ALREADY UNMAPPED");
+        require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
+
+        sourceTokenToDestinationToken[rootToken] = address(0);
+
+        emit TokenUnMapped(rootToken);
     }
 
     function _deposit(IERC721Metadata rootToken, address receiver, uint256 tokenId) private {

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -44,9 +44,9 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
             _withdraw(data[32:]);
         } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _withdrawBatch(data);
-        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG){
+        } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
-        }else{
+        } else {
             revert("RootERC721Predicate: INVALID_SIGNATURE");
         }
     }
@@ -104,11 +104,8 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         return childToken;
     }
 
-    function _unMapToken(bytes calldata data) private{
-        (address rootToken, , , ) = abi.decode(
-            data,
-            (address, address, address, uint256)
-        );
+    function _unMapToken(bytes calldata data) private {
+        (address rootToken, , , ) = abi.decode(data, (address, address, address, uint256));
         require(address(rootToken) != address(0), "RootERC721Predicate: TOKEN IS ALREADY UNMAPPED");
         require(sourceTokenToDestinationToken[address(rootToken)] != address(0));
 

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -177,12 +177,12 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
     }
 
     function _depositRollback(bytes calldata data) private {
-        (address rootToken, address depositor, , uint256 tokenId) = abi.decode(
+        (address rootToken, address sender, address receiver, uint256 tokenId) = abi.decode(
             data,
             (address, address, address, uint256)
         );
 
-        _withdrawInternal(rootToken, depositor, depositor, tokenId);
+        _withdrawInternal(rootToken, receiver, sender, tokenId);
     }
 
     function _withdraw(bytes calldata data) private {

--- a/contracts/bridge/RootERC721Predicate.sol
+++ b/contracts/bridge/RootERC721Predicate.sol
@@ -40,14 +40,32 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
         require(msg.sender == address(gateway), "RootERC721Predicate: ONLY_GATEWAY");
         require(sender == childERC721Predicate, "RootERC721Predicate: ONLY_CHILD_PREDICATE");
 
-        if (bytes32(data[:32]) == WITHDRAW_SIG || bytes32(data[:32]) == DEPOSIT_SIG) {
-            _withdraw(data[32:]);
-        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG || bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
+        if (bytes32(data[:32]) == WITHDRAW_SIG) {
+            _withdraw(data);
+        } else if (bytes32(data[:32]) == WITHDRAW_BATCH_SIG) {
+            _withdrawBatch(data);
+        } else {
+            revert("RootERC721Predicate: INVALID_SIGNATURE");
+        }
+    }
+
+    /**
+     * @inheritdoc IStateReceiver
+     * @notice Function to be used for token withdrawals for rollback
+     * @dev Can be extended to include other signatures for more functionality
+     */
+    function onStateRollback(uint256 /*  id */, address sender, bytes calldata data) external {
+        require(msg.sender == address(gateway), "RootERC20Predicate: ONLY_GATEWAY");
+        require(sender == address(this), "RootERC20Predicate: ONLY_ROOT_PREDICATE");
+
+        if (bytes32(data[:32]) == DEPOSIT_SIG) {
+            _withdraw(data);
+        } else if (bytes32(data[:32]) == DEPOSIT_BATCH_SIG) {
             _withdrawBatch(data);
         } else if (bytes32(data[:32]) == MAP_TOKEN_SIG) {
             _unMapToken(data[32:]);
         } else {
-            revert("RootERC721Predicate: INVALID_SIGNATURE");
+            revert("RootERC20Predicate: INVALID_SIGNATURE");
         }
     }
 
@@ -159,29 +177,45 @@ contract RootERC721Predicate is Predicate, Initializable, ERC721Holder, IRootERC
     }
 
     function _withdraw(bytes calldata data) private {
-        (address rootToken, address withdrawer, address receiver, uint256 tokenId) = abi.decode(
+        (bytes32 sig, address rootToken, address withdrawer, address receiver, uint256 tokenId) = abi.decode(
             data,
-            (address, address, address, uint256)
+            (bytes32, address, address, address, uint256)
         );
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
 
-        IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
+        if (sig == WITHDRAW_SIG) {
+            IERC721Metadata(rootToken).safeTransferFrom(address(this), receiver, tokenId);
+        } else {
+            IERC721Metadata(rootToken).safeTransferFrom(address(this), withdrawer, tokenId);
+        }
         // slither-disable-next-line reentrancy-events
         emit ERC721Withdraw(address(rootToken), childToken, withdrawer, receiver, tokenId);
     }
 
     function _withdrawBatch(bytes calldata data) private {
-        (, address rootToken, address withdrawer, address[] memory receivers, uint256[] memory tokenIds) = abi.decode(
-            data,
-            (bytes32, address, address, address[], uint256[])
-        );
+        (
+            bytes32 sig,
+            address rootToken,
+            address withdrawer,
+            address[] memory receivers,
+            uint256[] memory tokenIds
+        ) = abi.decode(data, (bytes32, address, address, address[], uint256[]));
         address childToken = sourceTokenToDestinationToken[rootToken];
         assert(childToken != address(0)); // invariant because child predicate should have already mapped tokens
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            IERC721Metadata(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i]);
-            unchecked {
-                ++i;
+        if (sig == WITHDRAW_BATCH_SIG)
+            for (uint256 i = 0; i < tokenIds.length; ) {
+                IERC721Metadata(rootToken).safeTransferFrom(address(this), receivers[i], tokenIds[i]);
+                unchecked {
+                    ++i;
+                }
+            }
+        else {
+            for (uint256 i = 0; i < tokenIds.length; ) {
+                IERC721Metadata(rootToken).safeTransferFrom(address(this), withdrawer, tokenIds[i]);
+                unchecked {
+                    ++i;
+                }
             }
         }
         // slither-disable-next-line reentrancy-events

--- a/contracts/interfaces/blade/IStateReceiver.sol
+++ b/contracts/interfaces/blade/IStateReceiver.sol
@@ -3,4 +3,6 @@ pragma solidity 0.8.19;
 
 interface IStateReceiver {
     function onStateReceive(uint256 counter, address sender, bytes calldata data) external;
+
+    function onStateRollback(uint256 id, address sender, bytes calldata data) external;
 }

--- a/contracts/interfaces/bridge/IRootERC1155Predicate.sol
+++ b/contracts/interfaces/bridge/IRootERC1155Predicate.sol
@@ -45,6 +45,7 @@ interface IRootERC1155Predicate is IStateReceiver {
         uint256[] amounts
     );
     event TokenMapped(address indexed rootToken, address indexed childToken);
+    event TokenUnMapped(address indexed rootToken);
 
     /**
      * @notice Function to deposit tokens from the depositor to themselves on the child chain

--- a/contracts/interfaces/bridge/IRootERC20Predicate.sol
+++ b/contracts/interfaces/bridge/IRootERC20Predicate.sol
@@ -27,6 +27,7 @@ interface IRootERC20Predicate is IStateReceiver {
         uint256 amount
     );
     event TokenMapped(address indexed rootToken, address indexed childToken);
+    event TokenUnMapped(address indexed rootToken);
 
     /**
      * @notice Function to deposit tokens from the depositor to themselves on the child chain

--- a/contracts/interfaces/bridge/IRootERC721Predicate.sol
+++ b/contracts/interfaces/bridge/IRootERC721Predicate.sol
@@ -34,6 +34,7 @@ interface IRootERC721Predicate is IStateReceiver {
         uint256[] tokenIds
     );
     event TokenMapped(address indexed rootToken, address indexed childToken);
+    event TokenUnMapped(address indexed rootToken);
 
     /**
      * @notice Function to deposit tokens from the depositor to themselves on the child chain

--- a/contracts/interfaces/bridge/IStateReceiver.sol
+++ b/contracts/interfaces/bridge/IStateReceiver.sol
@@ -8,4 +8,11 @@ interface IStateReceiver {
      * @param data Data sent by the sender
      */
     function onStateReceive(uint256 id, address sender, bytes calldata data) external;
+
+    /**
+     * @notice Called by gateway when state is received from source chain
+     * @param sender Address of the sender on the root chain
+     * @param data Data sent by the sender
+     */
+    function onStateRollback(uint256 id, address sender, bytes calldata data) external;
 }

--- a/docs/blade/ChildERC1155Predicate.md
+++ b/docs/blade/ChildERC1155Predicate.md
@@ -183,6 +183,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the child chain |
+| data | bytes | Data sent by the sender |
+
 ### rootERC1155Predicate
 
 ```solidity

--- a/docs/blade/ChildERC1155PredicateAccessList.md
+++ b/docs/blade/ChildERC1155PredicateAccessList.md
@@ -335,6 +335,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the child chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/ChildERC20Predicate.md
+++ b/docs/blade/ChildERC20Predicate.md
@@ -303,6 +303,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the child chain |
+| data | bytes | Data sent by the sender |
+
 ### rootERC20Predicate
 
 ```solidity

--- a/docs/blade/ChildERC20PredicateAccessList.md
+++ b/docs/blade/ChildERC20PredicateAccessList.md
@@ -337,6 +337,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the child chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/ChildERC721Predicate.md
+++ b/docs/blade/ChildERC721Predicate.md
@@ -183,6 +183,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the chain chain |
+| data | bytes | Data sent by the sender |
+
 ### rootERC721Predicate
 
 ```solidity

--- a/docs/blade/ChildERC721Predicate.md
+++ b/docs/blade/ChildERC721Predicate.md
@@ -198,7 +198,7 @@ Function to be used for token deposits for rollback
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-| sender | address | Address of the sender on the chain chain |
+| sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
 ### rootERC721Predicate

--- a/docs/blade/ChildERC721PredicateAccessList.md
+++ b/docs/blade/ChildERC721PredicateAccessList.md
@@ -335,6 +335,24 @@ Function to be used for token deposits
 | sender | address | Address of the sender on the root chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token deposits for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the chain chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/ChildERC721PredicateAccessList.md
+++ b/docs/blade/ChildERC721PredicateAccessList.md
@@ -350,7 +350,7 @@ Function to be used for token deposits for rollback
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-| sender | address | Address of the sender on the chain chain |
+| sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
 ### owner

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -312,6 +312,28 @@ function processedEvents(uint256) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
+### processedEventsRollback
+
+```solidity
+function processedEventsRollback(uint256) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
 ### receiveBatch
 
 ```solidity

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -368,6 +368,26 @@ function totalVotingPower() external view returns (uint256)
 
 ## Events
 
+### BridgeBatchResult
+
+```solidity
+event BridgeBatchResult(uint256 startId, uint256 endId, uint256 sourceChainId, uint256 destinationChainId, bool isRollback)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| startId  | uint256 | undefined |
+| endId  | uint256 | undefined |
+| sourceChainId  | uint256 | undefined |
+| destinationChainId  | uint256 | undefined |
+| isRollback  | bool | undefined |
+
 ### BridgeMessageResult
 
 ```solidity

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -391,7 +391,7 @@ event BridgeBatchResult(uint256 startId, uint256 endId, uint256 sourceChainId, u
 ### BridgeMessageResult
 
 ```solidity
-event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 sourceChainID, uint256 destinationChainID, bytes message, bool isRollback)
+event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 sourceChainID, uint256 destinationChainID, bytes message)
 ```
 
 
@@ -407,7 +407,6 @@ event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 
 | sourceChainID  | uint256 | undefined |
 | destinationChainID  | uint256 | undefined |
 | message  | bytes | undefined |
-| isRollback  | bool | undefined |
 
 ### BridgeMsg
 

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -371,7 +371,7 @@ function totalVotingPower() external view returns (uint256)
 ### BridgeMessageResult
 
 ```solidity
-event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 sourceChainID, uint256 destinationChainID, bytes message)
+event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 sourceChainID, uint256 destinationChainID, bytes message, bool isRollback)
 ```
 
 
@@ -387,6 +387,7 @@ event BridgeMessageResult(uint256 indexed counter, bool indexed status, uint256 
 | sourceChainID  | uint256 | undefined |
 | destinationChainID  | uint256 | undefined |
 | message  | bytes | undefined |
+| isRollback  | bool | undefined |
 
 ### BridgeMsg
 

--- a/docs/blade/RootMintableERC1155PredicateAccessList.md
+++ b/docs/blade/RootMintableERC1155PredicateAccessList.md
@@ -808,6 +808,22 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 
 ## Errors

--- a/docs/blade/RootMintableERC1155PredicateAccessList.md
+++ b/docs/blade/RootMintableERC1155PredicateAccessList.md
@@ -482,6 +482,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/RootMintableERC20PredicateAccessList.md
+++ b/docs/blade/RootMintableERC20PredicateAccessList.md
@@ -427,6 +427,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/RootMintableERC20PredicateAccessList.md
+++ b/docs/blade/RootMintableERC20PredicateAccessList.md
@@ -687,6 +687,22 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 
 ## Errors

--- a/docs/blade/RootMintableERC721PredicateAccessList.md
+++ b/docs/blade/RootMintableERC721PredicateAccessList.md
@@ -452,6 +452,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### owner
 
 ```solidity

--- a/docs/blade/RootMintableERC721PredicateAccessList.md
+++ b/docs/blade/RootMintableERC721PredicateAccessList.md
@@ -752,6 +752,22 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 
 ## Errors

--- a/docs/bridge/RootERC1155Predicate.md
+++ b/docs/bridge/RootERC1155Predicate.md
@@ -330,6 +330,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### sourceTokenToDestinationToken
 
 ```solidity

--- a/docs/bridge/RootERC1155Predicate.md
+++ b/docs/bridge/RootERC1155Predicate.md
@@ -495,5 +495,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/bridge/RootERC20Predicate.md
+++ b/docs/bridge/RootERC20Predicate.md
@@ -275,6 +275,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### sourceTokenToDestinationToken
 
 ```solidity

--- a/docs/bridge/RootERC20Predicate.md
+++ b/docs/bridge/RootERC20Predicate.md
@@ -374,5 +374,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/bridge/RootERC721Predicate.md
+++ b/docs/bridge/RootERC721Predicate.md
@@ -439,5 +439,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/bridge/RootERC721Predicate.md
+++ b/docs/bridge/RootERC721Predicate.md
@@ -300,6 +300,24 @@ Function to be used for token withdrawals
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256, address sender, bytes data) external nonpayable
+```
+
+Function to be used for token withdrawals for rollback
+
+*Can be extended to include other signatures for more functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 ### sourceTokenToDestinationToken
 
 ```solidity

--- a/docs/interfaces/blade/IChildERC1155Predicate.md
+++ b/docs/interfaces/blade/IChildERC1155Predicate.md
@@ -47,6 +47,24 @@ function onStateReceive(uint256 counter, address sender, bytes data) external no
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | undefined |
+| data | bytes | undefined |
+
 ### withdraw
 
 ```solidity

--- a/docs/interfaces/blade/IChildERC20Predicate.md
+++ b/docs/interfaces/blade/IChildERC20Predicate.md
@@ -48,6 +48,24 @@ function onStateReceive(uint256 counter, address sender, bytes data) external no
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | undefined |
+| data | bytes | undefined |
+
 ### withdraw
 
 ```solidity

--- a/docs/interfaces/blade/IChildERC721Predicate.md
+++ b/docs/interfaces/blade/IChildERC721Predicate.md
@@ -47,6 +47,24 @@ function onStateReceive(uint256 counter, address sender, bytes data) external no
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | undefined |
+| data | bytes | undefined |
+
 ### withdraw
 
 ```solidity

--- a/docs/interfaces/blade/IStateReceiver.md
+++ b/docs/interfaces/blade/IStateReceiver.md
@@ -28,6 +28,24 @@ function onStateReceive(uint256 counter, address sender, bytes data) external no
 | sender | address | undefined |
 | data | bytes | undefined |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | undefined |
+| data | bytes | undefined |
+
 
 
 

--- a/docs/interfaces/bridge/IRootERC1155Predicate.md
+++ b/docs/interfaces/bridge/IRootERC1155Predicate.md
@@ -106,6 +106,24 @@ Called by gateway when state is received from source chain
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+Called by gateway when state is received from source chain
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 
 
 ## Events

--- a/docs/interfaces/bridge/IRootERC1155Predicate.md
+++ b/docs/interfaces/bridge/IRootERC1155Predicate.md
@@ -211,5 +211,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/interfaces/bridge/IRootERC20Predicate.md
+++ b/docs/interfaces/bridge/IRootERC20Predicate.md
@@ -163,5 +163,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/interfaces/bridge/IRootERC20Predicate.md
+++ b/docs/interfaces/bridge/IRootERC20Predicate.md
@@ -102,6 +102,24 @@ Called by gateway when state is received from source chain
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+Called by gateway when state is received from source chain
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 
 
 ## Events

--- a/docs/interfaces/bridge/IRootERC721Predicate.md
+++ b/docs/interfaces/bridge/IRootERC721Predicate.md
@@ -204,5 +204,21 @@ event TokenMapped(address indexed rootToken, address indexed childToken)
 | rootToken `indexed` | address | undefined |
 | childToken `indexed` | address | undefined |
 
+### TokenUnMapped
+
+```solidity
+event TokenUnMapped(address indexed rootToken)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| rootToken `indexed` | address | undefined |
+
 
 

--- a/docs/interfaces/bridge/IRootERC721Predicate.md
+++ b/docs/interfaces/bridge/IRootERC721Predicate.md
@@ -103,6 +103,24 @@ Called by gateway when state is received from source chain
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+Called by gateway when state is received from source chain
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 
 
 ## Events

--- a/docs/interfaces/bridge/IStateReceiver.md
+++ b/docs/interfaces/bridge/IStateReceiver.md
@@ -28,6 +28,24 @@ Called by gateway when state is received from source chain
 | sender | address | Address of the sender on the child chain |
 | data | bytes | Data sent by the sender |
 
+### onStateRollback
+
+```solidity
+function onStateRollback(uint256 id, address sender, bytes data) external nonpayable
+```
+
+Called by gateway when state is received from source chain
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | undefined |
+| sender | address | Address of the sender on the root chain |
+| data | bytes | Data sent by the sender |
+
 
 
 

--- a/test/blade/ChildERC1155Predicate.test.ts
+++ b/test/blade/ChildERC1155Predicate.test.ts
@@ -496,9 +496,9 @@ describe("ChildERC1155Predicate", () => {
       ]
     );
 
-    await expect(systemChildERC1155Predicate.onStateRollback(0, systemChildERC1155Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC1155Predicate: ONLY_GATEWAY"
-    );
+    await expect(
+      systemChildERC1155Predicate.onStateRollback(0, systemChildERC1155Predicate.address, mappedData)
+    ).to.be.revertedWith("ChildERC1155Predicate: ONLY_GATEWAY");
   });
 
   it("OnStateRollback: failed only_child_predicate", async () => {
@@ -513,8 +513,8 @@ describe("ChildERC1155Predicate", () => {
       ]
     );
 
-    await expect(stateReceiverChildERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "ChildERC1155Predicate: ONLY_CHILD_PREDICATE"
-    );
+    await expect(
+      stateReceiverChildERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("ChildERC1155Predicate: ONLY_CHILD_PREDICATE");
   });
 });

--- a/test/blade/ChildERC1155Predicate.test.ts
+++ b/test/blade/ChildERC1155Predicate.test.ts
@@ -483,4 +483,55 @@ describe("ChildERC1155Predicate", () => {
       "ChildERC1155Predicate: NOT_CONTRACT"
     );
   });
+
+  it("OnStateRollback: failed unmapped_token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC1155Predicate.onStateRollback(0, stateReceiverChildERC1155Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC1155Predicate: UNMAPPED_TOKEN"
+    );
+  });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(systemChildERC1155Predicate.onStateRollback(0, systemChildERC1155Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC1155Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "ChildERC1155Predicate: ONLY_CHILD_PREDICATE"
+    );
+  });
 });

--- a/test/blade/ChildERC1155Predicate.test.ts
+++ b/test/blade/ChildERC1155Predicate.test.ts
@@ -484,23 +484,6 @@ describe("ChildERC1155Predicate", () => {
     );
   });
 
-  it("OnStateRollback: failed unmapped_token", async () => {
-    const mappedData = ethers.utils.defaultAbiCoder.encode(
-      ["bytes32", "address", "address", "address", "uint256"],
-      [
-        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
-        "0x0000000000000000000000000000000000000000",
-        accounts[0].address,
-        accounts[0].address,
-        1,
-      ]
-    );
-
-    await expect(stateReceiverChildERC1155Predicate.onStateRollback(0, stateReceiverChildERC1155Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC1155Predicate: UNMAPPED_TOKEN"
-    );
-  });
-
   it("OnStateRollback: failed only_gateway", async () => {
     const mappedData = ethers.utils.defaultAbiCoder.encode(
       ["bytes32", "address", "address", "address", "uint256"],

--- a/test/blade/ChildERC20Predicate.test.ts
+++ b/test/blade/ChildERC20Predicate.test.ts
@@ -424,9 +424,9 @@ describe("ChildERC20Predicate", () => {
       ]
     );
 
-    await expect(stateReceiverChildERC20Predicate.onStateRollback(0, stateReceiverChildERC20Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC20Predicate: UNMAPPED_TOKEN"
-    );
+    await expect(
+      stateReceiverChildERC20Predicate.onStateRollback(0, stateReceiverChildERC20Predicate.address, mappedData)
+    ).to.be.revertedWith("ChildERC20Predicate: UNMAPPED_TOKEN");
   });
 
   it("OnStateRollback: failed only_gateway", async () => {
@@ -441,9 +441,9 @@ describe("ChildERC20Predicate", () => {
       ]
     );
 
-    await expect(systemChildERC20Predicate.onStateRollback(0, systemChildERC20Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC20Predicate: ONLY_GATEWAY"
-    );
+    await expect(
+      systemChildERC20Predicate.onStateRollback(0, systemChildERC20Predicate.address, mappedData)
+    ).to.be.revertedWith("ChildERC20Predicate: ONLY_GATEWAY");
   });
 
   it("OnStateRollback: failed only_child_predicate", async () => {
@@ -458,8 +458,8 @@ describe("ChildERC20Predicate", () => {
       ]
     );
 
-    await expect(stateReceiverChildERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "ChildERC20Predicate: ONLY_CHILD_PREDICATE"
-    );
+    await expect(
+      stateReceiverChildERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("ChildERC20Predicate: ONLY_CHILD_PREDICATE");
   });
 });

--- a/test/blade/ChildERC20Predicate.test.ts
+++ b/test/blade/ChildERC20Predicate.test.ts
@@ -411,4 +411,55 @@ describe("ChildERC20Predicate", () => {
       "ChildERC20Predicate: BURN_FAILED"
     );
   });
+
+  it("OnStateRollback: failed unmapped_token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC20Predicate.onStateRollback(0, stateReceiverChildERC20Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC20Predicate: UNMAPPED_TOKEN"
+    );
+  });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(systemChildERC20Predicate.onStateRollback(0, systemChildERC20Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC20Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "ChildERC20Predicate: ONLY_CHILD_PREDICATE"
+    );
+  });
 });

--- a/test/blade/ChildERC721Predicate.test.ts
+++ b/test/blade/ChildERC721Predicate.test.ts
@@ -453,4 +453,55 @@ describe("ChildERC721Predicate", () => {
       stateReceiverChildERC721Predicate.withdrawBatch(childTokenAddr, [accounts[0].address], [1])
     ).to.be.revertedWith("ChildERC721Predicate: BURN_FAILED");
   });
+
+  it("OnStateRollback: failed unmapped_token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC721Predicate.onStateRollback(0, stateReceiverChildERC721Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC721Predicate: UNMAPPED_TOKEN"
+    );
+  });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(systemChildERC721Predicate.onStateRollback(0, systemChildERC721Predicate.address, mappedData)).to.be.revertedWith(
+      "ChildERC721Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(stateReceiverChildERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "ChildERC721Predicate: ONLY_CHILD_PREDICATE"
+    );
+  });
 });

--- a/test/blade/ChildERC721Predicate.test.ts
+++ b/test/blade/ChildERC721Predicate.test.ts
@@ -466,9 +466,9 @@ describe("ChildERC721Predicate", () => {
       ]
     );
 
-    await expect(stateReceiverChildERC721Predicate.onStateRollback(0, stateReceiverChildERC721Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC721Predicate: UNMAPPED_TOKEN"
-    );
+    await expect(
+      stateReceiverChildERC721Predicate.onStateRollback(0, stateReceiverChildERC721Predicate.address, mappedData)
+    ).to.be.revertedWith("ChildERC721Predicate: UNMAPPED_TOKEN");
   });
 
   it("OnStateRollback: failed only_gateway", async () => {
@@ -483,9 +483,9 @@ describe("ChildERC721Predicate", () => {
       ]
     );
 
-    await expect(systemChildERC721Predicate.onStateRollback(0, systemChildERC721Predicate.address, mappedData)).to.be.revertedWith(
-      "ChildERC721Predicate: ONLY_GATEWAY"
-    );
+    await expect(
+      systemChildERC721Predicate.onStateRollback(0, systemChildERC721Predicate.address, mappedData)
+    ).to.be.revertedWith("ChildERC721Predicate: ONLY_GATEWAY");
   });
 
   it("OnStateRollback: failed only_child_predicate", async () => {
@@ -500,8 +500,8 @@ describe("ChildERC721Predicate", () => {
       ]
     );
 
-    await expect(stateReceiverChildERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "ChildERC721Predicate: ONLY_CHILD_PREDICATE"
-    );
+    await expect(
+      stateReceiverChildERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("ChildERC721Predicate: ONLY_CHILD_PREDICATE");
   });
 });

--- a/test/blade/Gateway.test.ts
+++ b/test/blade/Gateway.test.ts
@@ -400,7 +400,7 @@ describe("Gateway", () => {
       },
     ];
     var batch: SignedBridgeMessageBatchStruct = {
-      threshold: 0,
+      threshold: 1000,
       isRollback: false,
       rootHash: "",
       startId: 1,

--- a/test/blade/Gateway.test.ts
+++ b/test/blade/Gateway.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as hre from "hardhat";
 import { ethers } from "hardhat";
-import { BLS, BN256G2, Gateway } from "../../typechain-types";
+import { BLS, BN256G2, ChildERC20Predicate, Gateway } from "../../typechain-types";
 import * as mcl from "../../ts/mcl";
 import { SignedBridgeMessageBatchStruct } from "../../typechain-types/contracts/blade/Gateway";
 
@@ -16,6 +16,7 @@ describe("Gateway", () => {
     bn256G2: BN256G2,
     validatorSetSize: number,
     validatorSecretKeys: any[],
+    childERC20Predicate: ChildERC20Predicate,
     validatorSet: any[],
     accounts: any[]; // we use any so we can access address directly from object
   before(async () => {
@@ -25,6 +26,10 @@ describe("Gateway", () => {
     const DestinationGateway = await ethers.getContractFactory("Gateway");
     gateway = (await DestinationGateway.deploy()) as Gateway;
     await gateway.deployed();
+
+    const ChildERC20Predicate = await ethers.getContractFactory("ChildERC20Predicate");
+    childERC20Predicate = await ChildERC20Predicate.deploy();
+    await childERC20Predicate.deployed();
 
     const BLS = await ethers.getContractFactory("BLS");
     bls = (await BLS.deploy()) as BLS;
@@ -369,7 +374,7 @@ describe("Gateway", () => {
     await expect(gateway.receiveBatch(msgs, batch)).to.be.revertedWith("INSUFFICIENT_VOTING_POWER");
   });
 
-  it("Gateway receiveBatch success", async () => {
+  it("Gateway receiveBatch success signature", async () => {
     msgs = [];
 
     const bitmapStr = "ffff";
@@ -382,7 +387,7 @@ describe("Gateway", () => {
         sourceChainId: 2,
         destinationChainId: 3,
         sender: ethers.constants.AddressZero,
-        receiver: ethers.constants.AddressZero,
+        receiver: childERC20Predicate.address,
         payload: ethers.constants.HashZero,
       },
       {
@@ -390,7 +395,7 @@ describe("Gateway", () => {
         sourceChainId: 2,
         destinationChainId: 3,
         sender: ethers.constants.AddressZero,
-        receiver: ethers.constants.AddressZero,
+        receiver: childERC20Predicate.address,
         payload: ethers.constants.HashZero,
       },
     ];
@@ -464,9 +469,6 @@ describe("Gateway", () => {
 
     batch.signature = aggMessagePoint;
 
-    const firstTx = await gateway.receiveBatch(msgs, batch);
-    const firstReceipt = await firstTx.wait();
-    const firstLogs = firstReceipt?.events?.filter((log) => log.event === "BridgeMessageResult") as any[];
-    expect(firstLogs).to.exist;
+    await expect(gateway.receiveBatch(msgs, batch)).to.be.revertedWith("Gateway: BATCH_ROLLBACK");
   });
 });

--- a/test/bridge/RootERC1155Predicate.test.ts
+++ b/test/bridge/RootERC1155Predicate.test.ts
@@ -358,7 +358,11 @@ describe("RootERC1155Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC1155Predicate.onStateRollback(0, exitHelperRootERC1155Predicate.address, mappedData);
+    const withdrawTx = await exitHelperRootERC1155Predicate.onStateRollback(
+      0,
+      exitHelperRootERC1155Predicate.address,
+      mappedData
+    );
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
@@ -393,8 +397,8 @@ describe("RootERC1155Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "RootERC1155Predicate: ONLY_ROOT_PREDICATE"
-    );
+    await expect(
+      exitHelperRootERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("RootERC1155Predicate: ONLY_ROOT_PREDICATE");
   });
 });

--- a/test/bridge/RootERC1155Predicate.test.ts
+++ b/test/bridge/RootERC1155Predicate.test.ts
@@ -311,4 +311,56 @@ describe("RootERC1155Predicate", () => {
     expect(withdrawEvent?.args?.tokenIds).to.deep.equal(ids);
     expect(withdrawEvent?.args?.amounts).to.deep.equal(amounts);
   });
+
+  it("unMapToken: revert invalid token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(
+      exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData)
+    ).to.be.revertedWith("RootERC1155Predicate: INVALID_TOKEN");
+  });
+
+  it("unMapToken: token unmapped", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(
+      exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData)
+    ).to.be.revertedWith("RootERC1155Predicate: TOKEN_IS_ALREADY_UNMAPPED");
+  });
+
+  it("unMapToken: success", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        rootToken.address,
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    const withdrawTx = await exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData);
+    const withdrawReceipt = await withdrawTx.wait();
+    const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
+    expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
+  });
 });

--- a/test/bridge/RootERC1155Predicate.test.ts
+++ b/test/bridge/RootERC1155Predicate.test.ts
@@ -325,7 +325,7 @@ describe("RootERC1155Predicate", () => {
     );
 
     await expect(
-      exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData)
+      exitHelperRootERC1155Predicate.onStateRollback(0, exitHelperRootERC1155Predicate.address, mappedData)
     ).to.be.revertedWith("RootERC1155Predicate: INVALID_TOKEN");
   });
 
@@ -342,7 +342,7 @@ describe("RootERC1155Predicate", () => {
     );
 
     await expect(
-      exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData)
+      exitHelperRootERC1155Predicate.onStateRollback(0, exitHelperRootERC1155Predicate.address, mappedData)
     ).to.be.revertedWith("RootERC1155Predicate: TOKEN_IS_ALREADY_UNMAPPED");
   });
 
@@ -358,9 +358,43 @@ describe("RootERC1155Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC1155Predicate.onStateReceive(0, childERC1155Predicate, mappedData);
+    const withdrawTx = await exitHelperRootERC1155Predicate.onStateRollback(0, exitHelperRootERC1155Predicate.address, mappedData);
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
+  });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["DEPOSIT"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(rootERC1155Predicate.onStateRollback(0, rootERC1155Predicate.address, mappedData)).to.be.revertedWith(
+      "RootERC1155Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC1155Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "RootERC1155Predicate: ONLY_ROOT_PREDICATE"
+    );
   });
 });

--- a/test/bridge/RootERC20Predicate.test.ts
+++ b/test/bridge/RootERC20Predicate.test.ts
@@ -294,7 +294,7 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData)).to.be.revertedWith(
+    await expect(exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)).to.be.revertedWith(
       "RootERC20Predicate: INVALID_TOKEN"
     );
   });
@@ -311,7 +311,7 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData)).to.be.revertedWith(
+    await expect(exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)).to.be.revertedWith(
       "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
     );
   });
@@ -328,9 +328,44 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData);
+    const withdrawTx = await exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData);
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
   });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["DEPOSIT"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(rootERC20Predicate.onStateRollback(0, rootERC20Predicate.address, mappedData)).to.be.revertedWith(
+      "RootERC20Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "RootERC20Predicate: ONLY_ROOT_PREDICATE"
+    );
+  });
+
 });

--- a/test/bridge/RootERC20Predicate.test.ts
+++ b/test/bridge/RootERC20Predicate.test.ts
@@ -294,9 +294,9 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)).to.be.revertedWith(
-      "RootERC20Predicate: INVALID_TOKEN"
-    );
+    await expect(
+      exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)
+    ).to.be.revertedWith("RootERC20Predicate: INVALID_TOKEN");
   });
 
   it("unMapToken: token unmapped", async () => {
@@ -311,9 +311,9 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)).to.be.revertedWith(
-      "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
-    );
+    await expect(
+      exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData)
+    ).to.be.revertedWith("RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED");
   });
 
   it("unMapToken: success", async () => {
@@ -328,7 +328,11 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC20Predicate.onStateRollback(0, exitHelperRootERC20Predicate.address, mappedData);
+    const withdrawTx = await exitHelperRootERC20Predicate.onStateRollback(
+      0,
+      exitHelperRootERC20Predicate.address,
+      mappedData
+    );
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
@@ -363,9 +367,8 @@ describe("RootERC20Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "RootERC20Predicate: ONLY_ROOT_PREDICATE"
-    );
+    await expect(
+      exitHelperRootERC20Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("RootERC20Predicate: ONLY_ROOT_PREDICATE");
   });
-
 });

--- a/test/bridge/RootERC20Predicate.test.ts
+++ b/test/bridge/RootERC20Predicate.test.ts
@@ -281,4 +281,56 @@ describe("RootERC20Predicate", () => {
     expect(withdrawEvent?.args?.receiver).to.equal(accounts[1].address);
     expect(withdrawEvent?.args?.amount).to.equal(ethers.utils.parseUnits(String(randomAmount)));
   });
+
+  it("unMapToken: revert invalid token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData)).to.be.revertedWith(
+      "RootERC20Predicate: INVALID_TOKEN"
+    );
+  });
+
+  it("unMapToken: token unmapped", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData)).to.be.revertedWith(
+      "RootERC20Predicate: TOKEN_IS_ALREADY_UNMAPPED"
+    );
+  });
+
+  it("unMapToken: success", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        rootToken.address,
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    const withdrawTx = await exitHelperRootERC20Predicate.onStateReceive(0, childERC20Predicate, mappedData);
+    const withdrawReceipt = await withdrawTx.wait();
+    const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
+    expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
+  });
 });

--- a/test/bridge/RootERC721Predicate.test.ts
+++ b/test/bridge/RootERC721Predicate.test.ts
@@ -312,4 +312,56 @@ describe("RootERC721Predicate", () => {
     expect(withdrawEvent?.args?.receivers).to.deep.equal(receiverArr);
     expect(withdrawEvent?.args?.tokenIds).to.deep.equal(depositedBatchIds.slice(0, batchSize));
   });
+
+  it("unMapToken: revert invalid token", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData)).to.be.revertedWith(
+      "RootERC721Predicate: INVALID_TOKEN"
+    );
+  });
+
+  it("unMapToken: token unmapped", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData)).to.be.revertedWith(
+      "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED"
+    );
+  });
+
+  it("unMapToken: success", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["MAP_TOKEN"]),
+        rootToken.address,
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    const withdrawTx = await exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData);
+    const withdrawReceipt = await withdrawTx.wait();
+    const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
+    expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
+  });
 });

--- a/test/bridge/RootERC721Predicate.test.ts
+++ b/test/bridge/RootERC721Predicate.test.ts
@@ -325,9 +325,9 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)).to.be.revertedWith(
-      "RootERC721Predicate: INVALID_TOKEN"
-    );
+    await expect(
+      exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)
+    ).to.be.revertedWith("RootERC721Predicate: INVALID_TOKEN");
   });
 
   it("unMapToken: token unmapped", async () => {
@@ -342,9 +342,9 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)).to.be.revertedWith(
-      "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED"
-    );
+    await expect(
+      exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)
+    ).to.be.revertedWith("RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED");
   });
 
   it("unMapToken: success", async () => {
@@ -359,7 +359,11 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData);
+    const withdrawTx = await exitHelperRootERC721Predicate.onStateRollback(
+      0,
+      exitHelperRootERC721Predicate.address,
+      mappedData
+    );
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
@@ -394,8 +398,8 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
-      "RootERC721Predicate: ONLY_ROOT_PREDICATE"
-    );
+    await expect(
+      exitHelperRootERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)
+    ).to.be.revertedWith("RootERC721Predicate: ONLY_ROOT_PREDICATE");
   });
 });

--- a/test/bridge/RootERC721Predicate.test.ts
+++ b/test/bridge/RootERC721Predicate.test.ts
@@ -325,7 +325,7 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData)).to.be.revertedWith(
+    await expect(exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)).to.be.revertedWith(
       "RootERC721Predicate: INVALID_TOKEN"
     );
   });
@@ -342,7 +342,7 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    await expect(exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData)).to.be.revertedWith(
+    await expect(exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData)).to.be.revertedWith(
       "RootERC721Predicate: TOKEN_IS_ALREADY_UNMAPPED"
     );
   });
@@ -359,9 +359,43 @@ describe("RootERC721Predicate", () => {
       ]
     );
 
-    const withdrawTx = await exitHelperRootERC721Predicate.onStateReceive(0, childERC721Predicate, mappedData);
+    const withdrawTx = await exitHelperRootERC721Predicate.onStateRollback(0, exitHelperRootERC721Predicate.address, mappedData);
     const withdrawReceipt = await withdrawTx.wait();
     const withdrawEvent = withdrawReceipt?.events?.find((log: any) => log.event === "TokenUnMapped");
     expect(withdrawEvent?.args?.rootToken).to.equal(rootToken.address);
+  });
+
+  it("OnStateRollback: failed only_gateway", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["DEPOSIT"]),
+        "0x0000000000000000000000000000000000000000",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(rootERC721Predicate.onStateRollback(0, rootERC721Predicate.address, mappedData)).to.be.revertedWith(
+      "RootERC721Predicate: ONLY_GATEWAY"
+    );
+  });
+
+  it("OnStateRollback: failed only_child_predicate", async () => {
+    const mappedData = ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "address", "address", "uint256"],
+      [
+        ethers.utils.solidityKeccak256(["string"], ["WITHDRAW"]),
+        "0x0000000000000000000000000000000000000001",
+        accounts[0].address,
+        accounts[0].address,
+        1,
+      ]
+    );
+
+    await expect(exitHelperRootERC721Predicate.onStateRollback(0, "0x0000000000000000000000000000000000000000", mappedData)).to.be.revertedWith(
+      "RootERC721Predicate: ONLY_ROOT_PREDICATE"
+    );
   });
 });

--- a/test/forge/blade/BridgeStorage.t.sol
+++ b/test/forge/blade/BridgeStorage.t.sol
@@ -151,7 +151,7 @@ contract BridgeStorageCommitBatchTests is BridgeStorageInitialized {
             destinationChainId: 3,
             signature: aggMessagePoints[3],
             bitmap: bitmaps[3],
-            threshold: 0,
+            threshold: 1000,
             isRollback: false
         });
 

--- a/test/forge/blade/Gateway.t.sol
+++ b/test/forge/blade/Gateway.t.sol
@@ -168,7 +168,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
         gateway.receiveBatch(msgs, batch);
     }
 
-    function testReceiveBatch_Success() public {
+    function testReceiveBatch_SuccessSignature() public {
         SignedBridgeMessageBatch memory batch = SignedBridgeMessageBatch({
             rootHash: 0,
             startId: msgs[0].id,
@@ -182,10 +182,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
         });
 
 
-        vm.expectEmit();
-        emit BridgeMessageResult(1, false, 2, 3, bytes(""), false);
-        vm.expectEmit();
-        emit BridgeMessageResult(2, false, 2, 3, bytes(""), false);
+        vm.expectRevert("Gateway: BATCH_ROLLBACK");
         gateway.receiveBatch(msgs, batch);
     }
 }

--- a/test/forge/blade/Gateway.t.sol
+++ b/test/forge/blade/Gateway.t.sol
@@ -181,8 +181,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
             isRollback: false
         });
 
-
-        vm.expectRevert("Gateway: BATCH_ROLLBACK");
+        vm.expectRevert("receiver has no code");
         gateway.receiveBatch(msgs, batch);
     }
 }

--- a/test/forge/blade/Gateway.t.sol
+++ b/test/forge/blade/Gateway.t.sol
@@ -126,7 +126,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
             destinationChainId: 3,
             signature: aggMessagePoints[0],
             bitmap: bitmaps[0],
-            threshold: 0,
+            threshold: 1000,
             isRollback: false
         });
 
@@ -143,7 +143,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
             destinationChainId: 3,
             signature: aggMessagePoints[1],
             bitmap: bitmaps[1],
-            threshold: 0,
+            threshold: 1000,
             isRollback: false
         });
 
@@ -160,7 +160,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
             destinationChainId: 3,
             signature: aggMessagePoints[2],
             bitmap: bitmaps[2],
-            threshold: 0,
+            threshold: 1000,
             isRollback: false
         });
 
@@ -177,7 +177,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
             destinationChainId: 3,
             signature: aggMessagePoints[3],
             bitmap: bitmaps[3],
-            threshold: 0,
+            threshold: 1000,
             isRollback: false
         });
 

--- a/test/forge/blade/Gateway.t.sol
+++ b/test/forge/blade/Gateway.t.sol
@@ -183,9 +183,9 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
 
 
         vm.expectEmit();
-        emit BridgeMessageResult(1, false, 2, 3, bytes(""));
+        emit BridgeMessageResult(1, false, 2, 3, bytes(""), false);
         vm.expectEmit();
-        emit BridgeMessageResult(2, false, 2, 3, bytes(""));
+        emit BridgeMessageResult(2, false, 2, 3, bytes(""), false);
         gateway.receiveBatch(msgs, batch);
     }
 }

--- a/test/forge/blade/generateMsgBridgeStorage.ts
+++ b/test/forge/blade/generateMsgBridgeStorage.ts
@@ -1,5 +1,6 @@
 import { ethers } from "hardhat";
 import * as mcl from "../../../ts/mcl";
+import { ChildERC20Predicate } from "../../../typechain-types";
 const input = process.argv[2];
 
 const sourceChainId = 2;
@@ -10,6 +11,7 @@ const destinationChainId = 3;
 
 let domain: any;
 
+let childERC20Predicate: ChildERC20Predicate
 let validatorSecretKeys: any[] = [];
 const validatorSetSize = Math.floor(Math.random() * (5 - 1) + 8); // Randomly pick 8 - 12
 let aggMessagePoints: mcl.MessagePoint[] = [];
@@ -38,6 +40,12 @@ let msgs = [
     payload: ethers.utils.id("2233"),
   },
 ];
+
+async function deploy() {
+  const ChildERC20Predicate = await ethers.getContractFactory("ChildERC20Predicate");
+  childERC20Predicate = await ChildERC20Predicate.deploy();
+  await childERC20Predicate.deployed();
+}
 
 async function generateMsg() {
   const input = process.argv[2];
@@ -232,13 +240,13 @@ function generateSignature3() {
 
   const encodedMessage1 = ethers.utils.defaultAbiCoder.encode(
     ["uint256", "uint256", "uint256", "address", "address", "bytes"],
-    [msgs[0].id, msgs[0].sourceChainId, msgs[0].destinationChainId, msgs[0].sender, msgs[0].receiver, msgs[0].payload]
+    [msgs[0].id, msgs[0].sourceChainId, msgs[0].destinationChainId, msgs[0].sender, childERC20Predicate.address, msgs[0].payload]
   );
   const hash1 = ethers.utils.keccak256(encodedMessage1);
 
   const encodedMessage2 = ethers.utils.defaultAbiCoder.encode(
     ["uint256", "uint256", "uint256", "address", "address", "bytes"],
-    [msgs[1].id, msgs[1].sourceChainId, msgs[1].destinationChainId, msgs[1].sender, msgs[1].receiver, msgs[1].payload]
+    [msgs[1].id, msgs[1].sourceChainId, msgs[1].destinationChainId, msgs[1].sender, childERC20Predicate.address, msgs[1].payload]
   );
   const hash2 = ethers.utils.keccak256(encodedMessage2);
 
@@ -278,4 +286,5 @@ function generateSignature3() {
   aggVotingPowers.push(aggVotingPower);
 }
 
+deploy();
 generateMsg();

--- a/test/forge/blade/generateMsgBridgeStorage.ts
+++ b/test/forge/blade/generateMsgBridgeStorage.ts
@@ -1,6 +1,5 @@
 import { ethers } from "hardhat";
 import * as mcl from "../../../ts/mcl";
-import { ChildERC20Predicate } from "../../../typechain-types";
 const input = process.argv[2];
 
 const sourceChainId = 2;
@@ -11,7 +10,6 @@ const destinationChainId = 3;
 
 let domain: any;
 
-let childERC20Predicate: ChildERC20Predicate
 let validatorSecretKeys: any[] = [];
 const validatorSetSize = Math.floor(Math.random() * (5 - 1) + 8); // Randomly pick 8 - 12
 let aggMessagePoints: mcl.MessagePoint[] = [];

--- a/test/forge/blade/generateMsgBridgeStorage.ts
+++ b/test/forge/blade/generateMsgBridgeStorage.ts
@@ -141,7 +141,7 @@ function generateSignature1() {
   const root = ethers.utils.keccak256(concatenatedHashes);
 
   const message = ethers.utils.keccak256(
-    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256", "uint256", "bool"], [root, 1, 2, 2, 3,0,false])
+    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256", "uint256", "bool"], [root, 1, 2, 2, 3,1000,false])
   );
 
   const signatures: mcl.Signature[] = [];
@@ -194,7 +194,7 @@ function generateSignature2() {
   const root = ethers.utils.keccak256(concatenatedHashes);
 
   const message = ethers.utils.keccak256(
-    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256", "uint256","bool"], [root, 1, 2, 2, 3, 0, false])
+    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256", "uint256","bool"], [root, 1, 2, 2, 3, 1000, false])
   );
   const signatures: mcl.Signature[] = [];
   let flag = false;
@@ -246,7 +246,7 @@ function generateSignature3() {
   const root = ethers.utils.keccak256(concatenatedHashes);
 
   const message = ethers.utils.keccak256(
-    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256","uint256","bool",], [root, 1, 2, 2, 3,0,false])
+    ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256","uint256","bool",], [root, 1, 2, 2, 3,1000,false])
   );
 
   const signatures: mcl.Signature[] = [];

--- a/test/forge/blade/generateMsgBridgeStorage.ts
+++ b/test/forge/blade/generateMsgBridgeStorage.ts
@@ -41,12 +41,6 @@ let msgs = [
   },
 ];
 
-async function deploy() {
-  const ChildERC20Predicate = await ethers.getContractFactory("ChildERC20Predicate");
-  childERC20Predicate = await ChildERC20Predicate.deploy();
-  await childERC20Predicate.deployed();
-}
-
 async function generateMsg() {
   const input = process.argv[2];
   const data = ethers.utils.defaultAbiCoder.decode(["bytes32"], input);
@@ -240,13 +234,13 @@ function generateSignature3() {
 
   const encodedMessage1 = ethers.utils.defaultAbiCoder.encode(
     ["uint256", "uint256", "uint256", "address", "address", "bytes"],
-    [msgs[0].id, msgs[0].sourceChainId, msgs[0].destinationChainId, msgs[0].sender, childERC20Predicate.address, msgs[0].payload]
+    [msgs[0].id, msgs[0].sourceChainId, msgs[0].destinationChainId, msgs[0].sender, msgs[0].receiver, msgs[0].payload]
   );
   const hash1 = ethers.utils.keccak256(encodedMessage1);
 
   const encodedMessage2 = ethers.utils.defaultAbiCoder.encode(
     ["uint256", "uint256", "uint256", "address", "address", "bytes"],
-    [msgs[1].id, msgs[1].sourceChainId, msgs[1].destinationChainId, msgs[1].sender, childERC20Predicate.address, msgs[1].payload]
+    [msgs[1].id, msgs[1].sourceChainId, msgs[1].destinationChainId, msgs[1].sender, msgs[0].receiver, msgs[1].payload]
   );
   const hash2 = ethers.utils.keccak256(encodedMessage2);
 
@@ -286,5 +280,4 @@ function generateSignature3() {
   aggVotingPowers.push(aggVotingPower);
 }
 
-deploy();
 generateMsg();


### PR DESCRIPTION
This PR introduces modifications to predicate contracts, allowing them to handle rollbacks more effectively.

### RootPredicates
In the RootPredicates contract, the `OnStateReceive` function now calls the `withdraw` function if the `data` received has a `DEPOSIT_SIG` prefix. This addition enables RootPredicates to identify and respond to a deposit operation that needs to be reverted, ensuring that funds can be rolled back if needed.

### ChildPredicates
Similarly, in the ChildPredicates contract, `OnStateReceive` now triggers a `deposit` call if the `data` provided carries a `WITHDRAW_SIG` prefix. This change allows ChildPredicates to handle rollbacks of withdrawal transactions, restoring tokens on the child chain as part of the rollback process.

### `_unMapToken` Function and Token Unmapping
A new `_unMapToken` function is introduced for unmapping tokens. When `data` in `OnStateReceive` includes a `MAP_TOKEN_SIG` prefix, the `_unMapToken` function is called. This ensures that tokens are properly unmapped if a mapping operation requires a rollback.

### Data Handling and Event Order
The mapping operation in `OnStateReceive` is consistently positioned at the end of the batch. This ordering is essential since any mapping rollback must occur after deposit or withdrawal actions. Only when a regular batch includes a mapping event does the mapping prefix appear, and reordering to position it at the end is handled by blade.

These changes enhance the predicate contracts' robustness by ensuring that rollbacks are handled accurately, supporting both deposit and withdrawal reversals as well as token unmapping where necessary.

### Revert Batch
If the execution of any individual bridge message within a batch fails, the entire batch will be reverted to maintain data consistency and prevent partial processing of messages.