### PR TITLE
Bridge storage refactoring

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -5,12 +5,10 @@ import "./ValidatorSetStorage.sol";
 
 contract BridgeStorage is ValidatorSetStorage {
     mapping(uint256 => SignedBridgeMessageBatch) public batches;
-    mapping(uint256 => SignedValidatorSet) public commitedValidatorSets;
     mapping(uint256 => uint256) public lastCommitted;
     mapping(uint256 => uint256) public lastCommittedInternal;
     /// @custom:security write-protection="onlySystemCall()"
     uint256 public batchCounter;
-    uint256 public validatorSetCounter;
 
     event NewBatch(uint256 indexed id);
     event NewValidatorSetStored(uint256 indexed id);
@@ -24,9 +22,7 @@ contract BridgeStorage is ValidatorSetStorage {
     function initialize(IBLS newBls, IBN256G2 newBn256G2, Validator[] calldata validators) public override initializer {
         bls = newBls;
         bn256G2 = newBn256G2;
-        _setNewValidatorSet(validators);
-
-        validatorSetCounter = 1;
+        _setInitialValidatorSet(validators);
     }
 
     /**
@@ -43,24 +39,9 @@ contract BridgeStorage is ValidatorSetStorage {
     ) external override onlySystemCall {
         _commitValidatorSet(newValidatorSet, signature, bitmap, blockMetadata);
 
-        SignedValidatorSet storage signedValidatorSet = commitedValidatorSets[validatorSetCounter];
-        signedValidatorSet.signature = signature;
-        signedValidatorSet.bitmap = bitmap;
-        signedValidatorSet.blockMetadata = blockMetadata;
-
-        uint256 length = newValidatorSet.length;
-        for (uint256 i = 0; i < length; ) {
-            signedValidatorSet.newValidatorSet.push(newValidatorSet[i]);
-            unchecked {
-                ++i;
-            }
-        }
-
         _insertNewValidatorSetBatchRef();
 
         emit NewValidatorSetStored(validatorSetCounter);
-
-        validatorSetCounter++;
     }
 
     /**
@@ -151,7 +132,7 @@ contract BridgeStorage is ValidatorSetStorage {
      * @param id validator set id
      */
     function getCommittedValidatorSet(uint256 id) external view returns (SignedValidatorSet memory) {
-        return commitedValidatorSets[id];
+        return committedValidatorSets[id];
     }
 
     /**

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -128,14 +128,6 @@ contract BridgeStorage is ValidatorSetStorage {
     }
 
     /**
-     * @notice Returns the committed validator set based on provided id
-     * @param id validator set id
-     */
-    function getCommittedValidatorSet(uint256 id) external view returns (SignedValidatorSet memory) {
-        return committedValidatorSets[id];
-    }
-
-    /**
      * @notice Inserts an empty batch used as a reference for each committed validator set batch
      */
     function _insertNewValidatorSetBatchRef() private {

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -177,4 +177,12 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
 
         emit NewValidatorSet(newValidatorSet);
     }
+
+    /**
+     * @notice Returns the committed validator set based on provided id
+     * @param id validator set id
+     */
+    function getCommittedValidatorSet(uint256 id) external view returns (SignedValidatorSet memory) {
+        return committedValidatorSets[id];
+    }
 }

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -11,7 +11,8 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
     IBLS public bls;
     IBN256G2 public bn256G2;
 
-    mapping(uint256 => Validator) public currentValidatorSet;
+    mapping(uint256 => SignedValidatorSet) committedValidatorSets;
+    uint256 public validatorSetCounter;
     uint256 public currentValidatorSetLength;
     bytes32 public currentValidatorSetHash;
     uint256 public totalVotingPower;
@@ -25,7 +26,7 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
     function initialize(IBLS newBls, IBN256G2 newBn256G2, Validator[] calldata validators) public virtual initializer {
         bls = newBls;
         bn256G2 = newBn256G2;
-        _setNewValidatorSet(validators);
+        _setInitialValidatorSet(validators);
     }
 
     /**
@@ -48,16 +49,16 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
      * @notice Internal function that sets the new validator set
      * @param newValidatorSet new validator set
      */
-    function _setNewValidatorSet(Validator[] calldata newValidatorSet) internal {
-        uint256 length = newValidatorSet.length;
-        currentValidatorSetLength = length;
+    function _setInitialValidatorSet(Validator[] calldata newValidatorSet) internal {
         currentValidatorSetHash = keccak256(abi.encode(newValidatorSet));
         uint256 totalPower = 0;
-        for (uint256 i = 0; i < length; ) {
+
+        SignedValidatorSet storage signedValidatorSet = committedValidatorSets[validatorSetCounter];
+        signedValidatorSet.newValidatorSet = newValidatorSet;
+        for (uint256 i = 0; i < committedValidatorSets[validatorSetCounter].newValidatorSet.length; ) {
             uint256 votingPower = newValidatorSet[i].votingPower;
             require(votingPower > 0, "VOTING_POWER_ZERO");
             totalPower += votingPower;
-            currentValidatorSet[i] = newValidatorSet[i];
             unchecked {
                 ++i;
             }
@@ -84,9 +85,9 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         for (uint256 i = 0; i < length; ) {
             if (_getValueFromBitmap(bitmap, i)) {
                 if (aggVotingPower == 0) {
-                    aggPubkey = currentValidatorSet[i].blsKey;
+                    aggPubkey = committedValidatorSets[validatorSetCounter].newValidatorSet[i].blsKey;
                 } else {
-                    uint256[4] memory blsKey = currentValidatorSet[i].blsKey;
+                    uint256[4] memory blsKey = committedValidatorSets[validatorSetCounter].newValidatorSet[i].blsKey;
                     // slither-disable-next-line calls-loop
                     (aggPubkey[0], aggPubkey[1], aggPubkey[2], aggPubkey[3]) = bn256G2.ecTwistAdd(
                         aggPubkey[0],
@@ -99,7 +100,7 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
                         blsKey[3]
                     );
                 }
-                aggVotingPower += currentValidatorSet[i].votingPower;
+                aggVotingPower += committedValidatorSets[validatorSetCounter].newValidatorSet[i].votingPower;
             }
             unchecked {
                 ++i;
@@ -151,7 +152,19 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
 
         verifySignature(bls.hashToPoint(DOMAIN_BRIDGE, hash), signature, bitmap);
 
-        _setNewValidatorSet(newValidatorSet);
+        validatorSetCounter++;
+
+        SignedValidatorSet storage signedValidatorSet = committedValidatorSets[validatorSetCounter];
+        signedValidatorSet.signature = signature;
+        signedValidatorSet.bitmap = bitmap;
+        signedValidatorSet.blockMetadata = blockMetadata;
+        uint256 length = newValidatorSet.length;
+        for (uint256 i = 0; i < length; ) {
+            signedValidatorSet.newValidatorSet.push(newValidatorSet[i]);
+            unchecked {
+                ++i;
+            }
+        }
 
         emit NewValidatorSet(newValidatorSet);
     }

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -78,11 +78,10 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         uint256[2] calldata signature,
         bytes calldata bitmap
     ) internal view {
-        uint256 length = currentValidatorSetLength;
         // slither-disable-next-line uninitialized-local
         uint256[4] memory aggPubkey;
         uint256 aggVotingPower = 0;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < committedValidatorSets[validatorSetCounter].newValidatorSet.length; ) {
             if (_getValueFromBitmap(bitmap, i)) {
                 if (aggVotingPower == 0) {
                     aggPubkey = committedValidatorSets[validatorSetCounter].newValidatorSet[i].blsKey;
@@ -138,6 +137,7 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
      * @param newValidatorSet The array of validators to be set as the new validator set
      * @param signature The aggregated signature of the validators that signed the new validator set
      * @param bitmap The bitmap representing which validators signed the new validator set
+     * @param blockMetadata The blockMetadata represents
      * Emits a `NewValidatorSet` event after successfully setting the new validator set.
      */
     function _commitValidatorSet(
@@ -146,6 +146,8 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         bytes calldata bitmap,
         BlockMetadata calldata blockMetadata
     ) internal {
+        uint256 totalPower = 0;
+
         require(newValidatorSet.length > 0, "EMPTY_VALIDATOR_SET");
 
         bytes memory hash = abi.encode(keccak256(abi.encode(blockMetadata)));
@@ -154,6 +156,8 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
 
         validatorSetCounter++;
 
+        currentValidatorSetHash = keccak256(abi.encode(newValidatorSet));
+
         SignedValidatorSet storage signedValidatorSet = committedValidatorSets[validatorSetCounter];
         signedValidatorSet.signature = signature;
         signedValidatorSet.bitmap = bitmap;
@@ -161,10 +165,15 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         uint256 length = newValidatorSet.length;
         for (uint256 i = 0; i < length; ) {
             signedValidatorSet.newValidatorSet.push(newValidatorSet[i]);
+            uint256 votingPower = newValidatorSet[i].votingPower;
+            require(votingPower > 0, "VOTING_POWER_ZERO");
+            totalPower += votingPower;
             unchecked {
                 ++i;
             }
         }
+
+        totalVotingPower = totalPower;
 
         emit NewValidatorSet(newValidatorSet);
     }

--- a/contracts/blade/ValidatorSetStorage.sol
+++ b/contracts/blade/ValidatorSetStorage.sol
@@ -54,8 +54,8 @@ contract ValidatorSetStorage is IValidatorSetStorage, Initializable, System {
         uint256 totalPower = 0;
 
         SignedValidatorSet storage signedValidatorSet = committedValidatorSets[validatorSetCounter];
-        signedValidatorSet.newValidatorSet = newValidatorSet;
-        for (uint256 i = 0; i < committedValidatorSets[validatorSetCounter].newValidatorSet.length; ) {
+        for (uint256 i = 0; i < newValidatorSet.length; ) {
+            signedValidatorSet.newValidatorSet.push(newValidatorSet[i]);
             uint256 votingPower = newValidatorSet[i].votingPower;
             require(votingPower > 0, "VOTING_POWER_ZERO");
             totalPower += votingPower;

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -245,52 +245,6 @@ function commitValidatorSet(Validator[] newValidatorSet, uint256[2] signature, b
 | bitmap | bytes | undefined |
 | blockMetadata | BlockMetadata | undefined |
 
-### commitedValidatorSets
-
-```solidity
-function commitedValidatorSets(uint256) external view returns (bytes bitmap, struct BlockMetadata blockMetadata)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| bitmap | bytes | undefined |
-| blockMetadata | BlockMetadata | undefined |
-
-### currentValidatorSet
-
-```solidity
-function currentValidatorSet(uint256) external view returns (address _address, uint256 votingPower)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _address | address | undefined |
-| votingPower | uint256 | undefined |
-
 ### currentValidatorSetHash
 
 ```solidity

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -250,6 +250,28 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### getCommittedValidatorSet
+
+```solidity
+function getCommittedValidatorSet(uint256 id) external view returns (struct SignedValidatorSet)
+```
+
+Returns the committed validator set based on provided id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | validator set id |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | SignedValidatorSet | undefined |
+
 ### getMessagesInRange
 
 ```solidity

--- a/docs/blade/Gateway.md
+++ b/docs/blade/Gateway.md
@@ -216,29 +216,6 @@ function counter() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### currentValidatorSet
-
-```solidity
-function currentValidatorSet(uint256) external view returns (address _address, uint256 votingPower)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _address | address | undefined |
-| votingPower | uint256 | undefined |
-
 ### currentValidatorSetHash
 
 ```solidity
@@ -397,6 +374,23 @@ Generates sync state event based on receiver and data. Anyone can call this meth
 
 ```solidity
 function totalVotingPower() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### validatorSetCounter
+
+```solidity
+function validatorSetCounter() external view returns (uint256)
 ```
 
 

--- a/docs/blade/TestRollbackGateway.md
+++ b/docs/blade/TestRollbackGateway.md
@@ -250,6 +250,28 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### getCommittedValidatorSet
+
+```solidity
+function getCommittedValidatorSet(uint256 id) external view returns (struct SignedValidatorSet)
+```
+
+Returns the committed validator set based on provided id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | validator set id |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | SignedValidatorSet | undefined |
+
 ### getMessagesInRange
 
 ```solidity

--- a/docs/blade/TestRollbackGateway.md
+++ b/docs/blade/TestRollbackGateway.md
@@ -216,29 +216,6 @@ function counter() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### currentValidatorSet
-
-```solidity
-function currentValidatorSet(uint256) external view returns (address _address, uint256 votingPower)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _address | address | undefined |
-| votingPower | uint256 | undefined |
-
 ### currentValidatorSetHash
 
 ```solidity
@@ -397,6 +374,23 @@ Generates sync state event based on receiver and data. Anyone can call this meth
 
 ```solidity
 function totalVotingPower() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### validatorSetCounter
+
+```solidity
+function validatorSetCounter() external view returns (uint256)
 ```
 
 

--- a/docs/blade/ValidatorSetStorage.md
+++ b/docs/blade/ValidatorSetStorage.md
@@ -182,29 +182,6 @@ function commitValidatorSet(Validator[] newValidatorSet, uint256[2] signature, b
 | bitmap | bytes | undefined |
 | blockMetadata | BlockMetadata | undefined |
 
-### currentValidatorSet
-
-```solidity
-function currentValidatorSet(uint256) external view returns (address _address, uint256 votingPower)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _address | address | undefined |
-| votingPower | uint256 | undefined |
-
 ### currentValidatorSetHash
 
 ```solidity
@@ -261,6 +238,23 @@ function initialize(contract IBLS newBls, contract IBN256G2 newBn256G2, Validato
 
 ```solidity
 function totalVotingPower() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### validatorSetCounter
+
+```solidity
+function validatorSetCounter() external view returns (uint256)
 ```
 
 

--- a/docs/blade/ValidatorSetStorage.md
+++ b/docs/blade/ValidatorSetStorage.md
@@ -216,6 +216,28 @@ function currentValidatorSetLength() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### getCommittedValidatorSet
+
+```solidity
+function getCommittedValidatorSet(uint256 id) external view returns (struct SignedValidatorSet)
+```
+
+Returns the committed validator set based on provided id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint256 | validator set id |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | SignedValidatorSet | undefined |
+
 ### initialize
 
 ```solidity


### PR DESCRIPTION
This pull request removes the validator set logic previously contained within `BridgeStorage.sol` and move it to `ValidatorSetStorage.sol`. This restructuring aims to separate concerns and improve code organization, ensuring that the validator set logic is handled independently within its dedicated contract.