### PR TITLE
feat: store rollbacked message ids E2I and I2E

### DIFF
--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -16,6 +16,10 @@ contract BridgeStorage is ValidatorSetStorage {
     /// @custom:security write-protection="onlySystemCall()"
     mapping(uint256 => uint256) public lastCommittedI2E;
     /// @custom:security write-protection="onlySystemCall()"
+    mapping(uint256 => uint256[]) public rollbackedE2I;
+    /// @custom:security write-protection="onlySystemCall()"
+    mapping(uint256 => uint256[]) public rollbackedI2E;
+    /// @custom:security write-protection="onlySystemCall()"
     mapping(bytes => uint256) public batchCommitCounter;
     /// @custom:security write-protection="onlySystemCall()"
     uint256 public batchCounter;
@@ -161,6 +165,14 @@ contract BridgeStorage is ValidatorSetStorage {
             unchecked {
                 ++i;
             }
+
+            if (message.isRollback) {
+                if (message.sourceChainId == block.chainid) {
+                    rollbackedI2E[message.destinationChainId].push(message.id);
+                } else {
+                    rollbackedE2I[message.sourceChainId].push(message.id);
+                }
+            }
         }
         if (batch.numberOfRegularEvents > 0) {
             if (batch.sourceChainId == block.chainid) {
@@ -215,6 +227,28 @@ contract BridgeStorage is ValidatorSetStorage {
         SignedBridgeMessageBatch storage newValidatorSetBatchRef = batches[batchCounter];
         newValidatorSetBatchRef.validatorSetBatchId = validatorSetCounter;
         batchCounter++;
+    }
+
+    function getConfirmedRollbackedI2E(uint256 chainId, uint256 id) external view returns (bool) {
+        uint256[] storage rollbacked = rollbackedI2E[chainId];
+        for (uint256 i = 0; i < rollbacked.length; i++) {
+            if (rollbacked[i] == id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function getConfirmedRollbackedE2I(uint256 chainId, uint256 id) external view returns (bool) {
+        uint256[] storage rollbacked = rollbackedE2I[chainId];
+        for (uint256 i = 0; i < rollbacked.length; i++) {
+            if (rollbacked[i] == id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/blade/BridgeStorage.sol
+++ b/contracts/blade/BridgeStorage.sol
@@ -229,6 +229,11 @@ contract BridgeStorage is ValidatorSetStorage {
         batchCounter++;
     }
 
+    /**
+     * @notice Returns true if message with id is rollbacked on I2E transfer, else false
+     * @param chainId external chain id
+     * @param id message id
+     */
     function getConfirmedRollbackedI2E(uint256 chainId, uint256 id) external view returns (bool) {
         uint256[] storage rollbacked = rollbackedI2E[chainId];
         for (uint256 i = 0; i < rollbacked.length; i++) {
@@ -240,6 +245,11 @@ contract BridgeStorage is ValidatorSetStorage {
         return false;
     }
 
+    /**
+     * @notice Returns true if message with id is rollbacked on E2I transfer, else false
+     * @param chainId external chain id
+     * @param id message id
+     */
     function getConfirmedRollbackedE2I(uint256 chainId, uint256 id) external view returns (bool) {
         uint256[] storage rollbacked = rollbackedE2I[chainId];
         for (uint256 i = 0; i < rollbacked.length; i++) {

--- a/docs/blade/BridgeStorage.md
+++ b/docs/blade/BridgeStorage.md
@@ -429,6 +429,52 @@ Returns the committed validator set based on provided id
 |---|---|---|
 | _0 | SignedValidatorSet | undefined |
 
+### getConfirmedRollbackedE2I
+
+```solidity
+function getConfirmedRollbackedE2I(uint256 chainId, uint256 id) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| chainId | uint256 | undefined |
+| id | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### getConfirmedRollbackedI2E
+
+```solidity
+function getConfirmedRollbackedI2E(uint256 chainId, uint256 id) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| chainId | uint256 | undefined |
+| id | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
 ### initialize
 
 ```solidity
@@ -503,6 +549,52 @@ function lastCommittedI2E(uint256) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### rollbackedE2I
+
+```solidity
+function rollbackedE2I(uint256, uint256) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| _1 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### rollbackedI2E
+
+```solidity
+function rollbackedI2E(uint256, uint256) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| _1 | uint256 | undefined |
 
 #### Returns
 


### PR DESCRIPTION
This feature covers adding rollbacked message ids to BridgeStorage contract for E2I & I2E transfers.
Also, it features get methods that check whether message was rollbacked or not.