### PR TITLE
Contracts cleanup

### DIFF
--- a/contracts/bridge/common/Gateway.sol
+++ b/contracts/bridge/common/Gateway.sol
@@ -96,7 +96,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
                     signedBatch.batch.sourceChainId,
                     signedBatch.batch.destinationChainId,
                     signedBatch.batch.threshold,
-                    signedBatch.batch.numberOfRegularEvents,
                     signedBatch.batch.commitCounter
                 )
             )

--- a/contracts/bridge/common/Gateway.sol
+++ b/contracts/bridge/common/Gateway.sol
@@ -34,8 +34,6 @@ contract Gateway is ValidatorSetStorage, IGateway {
         bytes data
     );
 
-    event BridgeBatchProcessed(bool success, uint256 sourceChainId, uint256 destinationChainId, bytes batchHash);
-
     /**
      * @notice initializes the contract
      * @param newBls address of the BLS library contract
@@ -111,37 +109,24 @@ contract Gateway is ValidatorSetStorage, IGateway {
         }
 
         uint256 length = signedBatch.batch.messages.length;
-        uint256 executedMessages = 0;
         for (uint256 i = 0; i < length; ) {
             if (!signedBatch.batch.messages[i].isRollback) {
                 if (processedEvents[signedBatch.batch.messages[i].id]) continue;
 
                 processedEvents[signedBatch.batch.messages[i].id] = true;
 
-                executedMessages++;
                 _executeBridgeMessage(signedBatch.batch.messages[i]);
             } else {
                 if (processedEventsRollback[signedBatch.batch.messages[i].id]) continue;
 
                 processedEventsRollback[signedBatch.batch.messages[i].id] = true;
 
-                executedMessages++;
                 _executeRollbackBridgeMessage(signedBatch.batch.messages[i]);
             }
 
             unchecked {
                 ++i;
             }
-        }
-
-        if (executedMessages > 0) {
-            // slither-disable-next-line reentrancy-events
-            emit BridgeBatchProcessed(
-                false,
-                signedBatch.batch.sourceChainId,
-                signedBatch.batch.destinationChainId,
-                hash
-            );
         }
     }
 

--- a/contracts/bridge/common/TestRollbackGateway.sol
+++ b/contracts/bridge/common/TestRollbackGateway.sol
@@ -55,9 +55,6 @@ contract TestRollbackGateway is Gateway {
                 ++i;
             }
         }
-
-        // slither-disable-next-line reentrancy-events
-        emit BridgeBatchProcessed(true, signedBatch.batch.sourceChainId, signedBatch.batch.destinationChainId, hash);
     }
     // slither-disable-end reentrancy-benign
 }

--- a/contracts/bridge/common/TestRollbackGateway.sol
+++ b/contracts/bridge/common/TestRollbackGateway.sol
@@ -23,7 +23,6 @@ contract TestRollbackGateway is Gateway {
                     signedBatch.batch.sourceChainId,
                     signedBatch.batch.destinationChainId,
                     signedBatch.batch.threshold,
-                    signedBatch.batch.numberOfRegularEvents,
                     signedBatch.batch.commitCounter
                 )
             )

--- a/contracts/bridge/internal/BridgeStorage.sol
+++ b/contracts/bridge/internal/BridgeStorage.sol
@@ -175,14 +175,14 @@ contract BridgeStorage is ValidatorSetStorage {
                     rollbackedI2E[message.destinationChainId].push(message.id);
                 } else {
                     require(
-                        !getConfirmedRollbackedE2I(message.destinationChainId, message.id),
+                        !getConfirmedRollbackedE2I(message.sourceChainId, message.id),
                         "ROLLBACK_MESSAGE_ALREADY_ROLLBACKED"
                     );
                     rollbackedE2I[message.sourceChainId].push(message.id);
                 }
             }
         }
-        if (batch.commitCounter == 1) {
+        if (batch.commitCounter == 1 && batch.numberOfRegularEvents > 0) {
             if (batch.sourceChainId == block.chainid) {
                 require(
                     lastCommittedI2E[batch.destinationChainId] + 1 == batch.messages[0].id,

--- a/contracts/bridge/internal/BridgeStorage.sol
+++ b/contracts/bridge/internal/BridgeStorage.sol
@@ -156,7 +156,7 @@ contract BridgeStorage is ValidatorSetStorage {
 
         require(batch.messages.length > 0, "EMPTY_BATCH");
 
-        uint256 numberOfRegularMessages = 0;
+        uint256 numberOfOrdinaryMessages = 0;
 
         for (uint256 i = 0; i < batch.messages.length; ) {
             BridgeMessage memory message = batch.messages[i];
@@ -181,19 +181,19 @@ contract BridgeStorage is ValidatorSetStorage {
                     rollbackedE2I[message.sourceChainId].push(message.id);
                 }
             } else {
-                numberOfRegularMessages++;
+                numberOfOrdinaryMessages++;
             }
         }
-        if (numberOfRegularMessages > 0) {
+        if (numberOfOrdinaryMessages > 0) {
             if (batch.sourceChainId == block.chainid) {
                 require(
                     lastCommittedI2E[batch.destinationChainId] + 1 == batch.messages[0].id,
                     "INVALID_LAST_COMMITTED"
                 );
-                lastCommittedI2E[batch.destinationChainId] = batch.messages[numberOfRegularMessages - 1].id;
+                lastCommittedI2E[batch.destinationChainId] = batch.messages[numberOfOrdinaryMessages - 1].id;
             } else {
                 require(lastCommittedE2I[batch.sourceChainId] + 1 == batch.messages[0].id, "INVALID_LAST_COMMITTED");
-                lastCommittedE2I[batch.sourceChainId] = batch.messages[numberOfRegularMessages - 1].id;
+                lastCommittedE2I[batch.sourceChainId] = batch.messages[numberOfOrdinaryMessages - 1].id;
             }
         }
     }

--- a/contracts/bridge/internal/BridgeStorage.sol
+++ b/contracts/bridge/internal/BridgeStorage.sol
@@ -127,7 +127,7 @@ contract BridgeStorage is ValidatorSetStorage {
                     signedBatch.batch.sourceChainId,
                     signedBatch.batch.destinationChainId,
                     0,
-                    0,
+                    signedBatch.batch.numberOfRegularEvents,
                     0
                 )
             )
@@ -166,15 +166,23 @@ contract BridgeStorage is ValidatorSetStorage {
                 ++i;
             }
 
-            if (message.isRollback) {
+            if (batch.commitCounter == 1 && message.isRollback) {
                 if (message.sourceChainId == block.chainid) {
+                    require(
+                        !getConfirmedRollbackedI2E(message.destinationChainId, message.id),
+                        "ROLLBACK_MESSAGE_ALREADY_ROLLBACKED"
+                    );
                     rollbackedI2E[message.destinationChainId].push(message.id);
                 } else {
+                    require(
+                        !getConfirmedRollbackedE2I(message.destinationChainId, message.id),
+                        "ROLLBACK_MESSAGE_ALREADY_ROLLBACKED"
+                    );
                     rollbackedE2I[message.sourceChainId].push(message.id);
                 }
             }
         }
-        if (batch.numberOfRegularEvents > 0) {
+        if (batch.commitCounter == 1) {
             if (batch.sourceChainId == block.chainid) {
                 require(
                     lastCommittedI2E[batch.destinationChainId] + 1 == batch.messages[0].id,
@@ -234,7 +242,7 @@ contract BridgeStorage is ValidatorSetStorage {
      * @param chainId external chain id
      * @param id message id
      */
-    function getConfirmedRollbackedI2E(uint256 chainId, uint256 id) external view returns (bool) {
+    function getConfirmedRollbackedI2E(uint256 chainId, uint256 id) public view returns (bool) {
         uint256[] storage rollbacked = rollbackedI2E[chainId];
         for (uint256 i = 0; i < rollbacked.length; i++) {
             if (rollbacked[i] == id) {
@@ -250,7 +258,7 @@ contract BridgeStorage is ValidatorSetStorage {
      * @param chainId external chain id
      * @param id message id
      */
-    function getConfirmedRollbackedE2I(uint256 chainId, uint256 id) external view returns (bool) {
+    function getConfirmedRollbackedE2I(uint256 chainId, uint256 id) public view returns (bool) {
         uint256[] storage rollbacked = rollbackedE2I[chainId];
         for (uint256 i = 0; i < rollbacked.length; i++) {
             if (rollbacked[i] == id) {

--- a/contracts/bridge/internal/BridgeStorage.sol
+++ b/contracts/bridge/internal/BridgeStorage.sol
@@ -112,7 +112,6 @@ contract BridgeStorage is ValidatorSetStorage {
                     signedBatch.batch.sourceChainId,
                     signedBatch.batch.destinationChainId,
                     signedBatch.batch.threshold,
-                    signedBatch.batch.numberOfRegularEvents,
                     signedBatch.batch.commitCounter
                 )
             )
@@ -127,7 +126,6 @@ contract BridgeStorage is ValidatorSetStorage {
                     signedBatch.batch.sourceChainId,
                     signedBatch.batch.destinationChainId,
                     0,
-                    signedBatch.batch.numberOfRegularEvents,
                     0
                 )
             )
@@ -152,11 +150,13 @@ contract BridgeStorage is ValidatorSetStorage {
      * @param batch batch to verify
      */
     function _verifyBatch(BridgeMessageBatch calldata batch) private {
+        if (batch.commitCounter > 1) {
+            return; // when commitCounter is greater than one, we resubmit the old batch, so we don’t need to verify the batch again.
+        }
+
         require(batch.messages.length > 0, "EMPTY_BATCH");
-        require(
-            batch.numberOfRegularEvents <= batch.messages.length,
-            "NUMBER_OF_EVENTS_IS_GREATER_THAN_MESSAGE_LENGTH"
-        );
+
+        uint256 numberOfRegularMessages = 0;
 
         for (uint256 i = 0; i < batch.messages.length; ) {
             BridgeMessage memory message = batch.messages[i];
@@ -166,7 +166,7 @@ contract BridgeStorage is ValidatorSetStorage {
                 ++i;
             }
 
-            if (batch.commitCounter == 1 && message.isRollback) {
+            if (message.isRollback) {
                 if (message.sourceChainId == block.chainid) {
                     require(
                         !getConfirmedRollbackedI2E(message.destinationChainId, message.id),
@@ -180,18 +180,20 @@ contract BridgeStorage is ValidatorSetStorage {
                     );
                     rollbackedE2I[message.sourceChainId].push(message.id);
                 }
+            } else {
+                numberOfRegularMessages++;
             }
         }
-        if (batch.commitCounter == 1 && batch.numberOfRegularEvents > 0) {
+        if (numberOfRegularMessages > 0) {
             if (batch.sourceChainId == block.chainid) {
                 require(
                     lastCommittedI2E[batch.destinationChainId] + 1 == batch.messages[0].id,
                     "INVALID_LAST_COMMITTED"
                 );
-                lastCommittedI2E[batch.destinationChainId] = batch.messages[batch.numberOfRegularEvents - 1].id;
+                lastCommittedI2E[batch.destinationChainId] = batch.messages[numberOfRegularMessages - 1].id;
             } else {
                 require(lastCommittedE2I[batch.sourceChainId] + 1 == batch.messages[0].id, "INVALID_LAST_COMMITTED");
-                lastCommittedE2I[batch.sourceChainId] = batch.messages[batch.numberOfRegularEvents - 1].id;
+                lastCommittedE2I[batch.sourceChainId] = batch.messages[numberOfRegularMessages - 1].id;
             }
         }
     }

--- a/contracts/interfaces/bridge/IValidatorSetStorage.sol
+++ b/contracts/interfaces/bridge/IValidatorSetStorage.sol
@@ -45,7 +45,6 @@ struct BridgeMessageBatch {
     uint256 sourceChainId;
     uint256 destinationChainId;
     uint256 threshold;
-    uint256 numberOfRegularEvents;
     uint256 commitCounter;
 }
 

--- a/docs/bridge/common/Gateway.md
+++ b/docs/bridge/common/Gateway.md
@@ -426,25 +426,6 @@ function totalVotingPower() external view returns (uint256)
 
 ## Events
 
-### BridgeBatchProcessed
-
-```solidity
-event BridgeBatchProcessed(bool success, uint256 sourceChainId, uint256 destinationChainId, bytes batchHash)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| success  | bool | undefined |
-| sourceChainId  | uint256 | undefined |
-| destinationChainId  | uint256 | undefined |
-| batchHash  | bytes | undefined |
-
 ### BridgeMessageResult
 
 ```solidity

--- a/docs/bridge/common/TestRollbackGateway.md
+++ b/docs/bridge/common/TestRollbackGateway.md
@@ -426,25 +426,6 @@ function totalVotingPower() external view returns (uint256)
 
 ## Events
 
-### BridgeBatchProcessed
-
-```solidity
-event BridgeBatchProcessed(bool success, uint256 sourceChainId, uint256 destinationChainId, bytes batchHash)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| success  | bool | undefined |
-| sourceChainId  | uint256 | undefined |
-| destinationChainId  | uint256 | undefined |
-| batchHash  | bytes | undefined |
-
 ### BridgeMessageResult
 
 ```solidity

--- a/test/blade/BridgeStorage.test.ts
+++ b/test/blade/BridgeStorage.test.ts
@@ -97,7 +97,6 @@ describe("BridgeStorage", () => {
       messages: msgs,
       threshold: 0,
       sourceChainId: sourceChainId,
-      numberOfRegularEvents: 1,
       destinationChainId: destinationChainId,
       commitCounter: 0,
     };
@@ -145,7 +144,6 @@ describe("BridgeStorage", () => {
     const batch: BridgeMessageBatchStruct = {
       messages: msgs,
       threshold: 0,
-      numberOfRegularEvents: 2,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
       commitCounter: 0,
@@ -224,7 +222,6 @@ describe("BridgeStorage", () => {
       threshold: 0,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 
@@ -243,16 +240,8 @@ describe("BridgeStorage", () => {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
-        [
-          batch.messages,
-          batch.sourceChainId,
-          batch.destinationChainId,
-          batch.threshold,
-          batch.numberOfRegularEvents,
-          batch.commitCounter,
-        ]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 
@@ -320,7 +309,6 @@ describe("BridgeStorage", () => {
       threshold: 0,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 
@@ -339,16 +327,8 @@ describe("BridgeStorage", () => {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
-        [
-          batch.messages,
-          batch.sourceChainId,
-          batch.destinationChainId,
-          batch.threshold,
-          batch.numberOfRegularEvents,
-          batch.commitCounter,
-        ]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 
@@ -416,7 +396,6 @@ describe("BridgeStorage", () => {
       threshold: 0,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
-      numberOfRegularEvents: 2,
       commitCounter: 1,
     };
 
@@ -435,16 +414,8 @@ describe("BridgeStorage", () => {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
-        [
-          batch.messages,
-          batch.sourceChainId,
-          batch.destinationChainId,
-          batch.threshold,
-          batch.numberOfRegularEvents,
-          batch.commitCounter,
-        ]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 
@@ -494,7 +465,6 @@ describe("BridgeStorage", () => {
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
       threshold: 0,
-      numberOfRegularEvents: 0,
       commitCounter: 0,
     };
 
@@ -541,7 +511,6 @@ describe("BridgeStorage", () => {
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
       threshold: 0,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 

--- a/test/blade/Gateway.test.ts
+++ b/test/blade/Gateway.test.ts
@@ -147,7 +147,6 @@ describe("Gateway", () => {
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
       threshold: 0,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 
@@ -224,7 +223,6 @@ describe("Gateway", () => {
       threshold: 0,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 
@@ -243,16 +241,8 @@ describe("Gateway", () => {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
-        [
-          batch.messages,
-          batch.sourceChainId,
-          batch.destinationChainId,
-          batch.threshold,
-          batch.numberOfRegularEvents,
-          batch.commitCounter,
-        ]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 
@@ -320,7 +310,6 @@ describe("Gateway", () => {
       threshold: 0,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
-      numberOfRegularEvents: 2,
       commitCounter: 0,
     };
 
@@ -340,7 +329,7 @@ describe("Gateway", () => {
           "uint256",
           "uint256",
         ],
-        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.numberOfRegularEvents]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 
@@ -405,7 +394,6 @@ describe("Gateway", () => {
     var batch: BridgeMessageBatchStruct = {
       messages: msgs,
       threshold: 1000,
-      numberOfRegularEvents: 2,
       sourceChainId: sourceChainId,
       destinationChainId: destinationChainId,
       commitCounter: 0,
@@ -426,16 +414,8 @@ describe("Gateway", () => {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
-        [
-          batch.messages,
-          batch.sourceChainId,
-          batch.destinationChainId,
-          batch.threshold,
-          batch.numberOfRegularEvents,
-          batch.commitCounter,
-        ]
+        [batch.messages, batch.sourceChainId, batch.destinationChainId, batch.threshold, batch.commitCounter]
       )
     );
 

--- a/test/forge/blade/BridgeStorage.t.sol
+++ b/test/forge/blade/BridgeStorage.t.sol
@@ -77,7 +77,7 @@ contract BridgeStorageUnitialized is BridgeStorageTest {
 
 contract BridgeStorageCommitBatchTests is BridgeStorageInitialized {
     function testCommitBatch_InvalidSignature() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, commitCounter: 1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[0], bitmap: bitmaps[0], validatorSetBatchId: 0});
 
@@ -86,7 +86,7 @@ contract BridgeStorageCommitBatchTests is BridgeStorageInitialized {
     }
 
     function testCommitBatch_EmptyBitmap() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, commitCounter: 1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[1], bitmap: bitmaps[1], validatorSetBatchId: 0});
 
@@ -95,7 +95,7 @@ contract BridgeStorageCommitBatchTests is BridgeStorageInitialized {
     }
 
     function testCommitBatch_NotEnoughPower() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, commitCounter: 1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[2], bitmap: bitmaps[2], validatorSetBatchId: 0});
 
@@ -104,7 +104,7 @@ contract BridgeStorageCommitBatchTests is BridgeStorageInitialized {
     }
 
     function testCommitBatch_Success() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3,threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3,threshold: 1000, commitCounter: 1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[3], bitmap: bitmaps[3], validatorSetBatchId: 0});
 

--- a/test/forge/blade/Gateway.t.sol
+++ b/test/forge/blade/Gateway.t.sol
@@ -118,7 +118,7 @@ contract GatewayStateSyncTest is GatewayInitialized {
 
 contract GatewayReceiveBatchTests is GatewayInitialized {
     function testReceiveBatch_InvalidSignature() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000,commitCounter: 1});
 
         SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[0], bitmap: bitmaps[0], validatorSetBatchId: 0});
 
@@ -127,7 +127,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
     }
 
     function testReceiveBatch_EmptyBitmap() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, commitCounter: 1});
 
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[1], bitmap: bitmaps[1], validatorSetBatchId: 0});
@@ -137,7 +137,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
     }
 
     function testReceiveBatch_NotEnoughPower() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter:1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, commitCounter:1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[2], bitmap: bitmaps[2], validatorSetBatchId: 0});
 
@@ -146,7 +146,7 @@ contract GatewayReceiveBatchTests is GatewayInitialized {
     }
 
     function testReceiveBatch_Success() public {
-        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000, numberOfRegularEvents: 2, commitCounter: 1});
+        BridgeMessageBatch memory batch = BridgeMessageBatch({messages: msgs, sourceChainId: 2, destinationChainId: 3, threshold: 1000,commitCounter: 1});
 
          SignedBridgeMessageBatch memory signedBatch = SignedBridgeMessageBatch({batch: batch, signature:aggMessagePoints[3], bitmap: bitmaps[3], validatorSetBatchId: 0});
 

--- a/test/forge/blade/generateMsgBridgeStorage.ts
+++ b/test/forge/blade/generateMsgBridgeStorage.ts
@@ -44,7 +44,6 @@ let batch = {
   sourceChainId: sourceChainId,
   destinationChainId: destinationChainId,
   threshold: 1000,
-  numberOfRegularEvents: 2,
   commitCounter: 1
 };
 
@@ -140,14 +139,12 @@ function generateSignature1() {
         "uint256",
         "uint256",
         "uint256",
-        "uint256",
       ],
       [
         batch.messages,
         batch.sourceChainId,
         batch.destinationChainId,
         batch.threshold,
-        batch.numberOfRegularEvents,
         batch.commitCounter,
       ]
     )
@@ -195,14 +192,12 @@ function generateSignature2() {
         "uint256",
         "uint256",
         "uint256",
-        "uint256",
       ],
       [
         batch.messages,
         batch.sourceChainId,
         batch.destinationChainId,
         batch.threshold,
-        batch.numberOfRegularEvents,
         batch.commitCounter,
       ]
     )
@@ -250,14 +245,12 @@ function generateSignature3() {
           "uint256",
           "uint256",
           "uint256",
-          "uint256",
         ],
         [
           batch.messages,
           batch.sourceChainId,
           batch.destinationChainId,
           batch.threshold,
-          batch.numberOfRegularEvents,
           batch.commitCounter,
         ]
       )


### PR DESCRIPTION
This PR includes several modifications to the `verifyBatch` function in `BridgeStorage.sol`. Previously, the `numberOfRegularEvents` was precomputed on the Blade side. However, this is no longer necessary, as the calculation is now performed while iterating through all messages within the batch during verification.

Additionally, the process for computing the batch hash has been updated, as the `numberOfRegularEvents` is no longer included in the batch structure. Furthermore, batch verification is now performed only for batches that are being committed for the first time, ensuring that redundant verifications are avoided.